### PR TITLE
Reinstate CHERIoT-RTOS to fix sw build

### DIFF
--- a/scratch_sw/bare_metal/CMakeLists.txt
+++ b/scratch_sw/bare_metal/CMakeLists.txt
@@ -2,10 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 include(FetchContent)
 
 FetchContent_Declare(CHERIOT_RTOS
-  GIT_REPOSITORY    https://github.com/lowRISC/CHERIoT-RTOS
-  GIT_TAG           bf7584e971c553160d266c21e17a38635b349a38
-#  GIT_REPOSITORY    https://github.com/CHERIoT-Platform/CHERIoT-RTOS
-#  GIT_TAG           64d846091a43053fbdd0312fb9419e05429109c6
+  GIT_REPOSITORY    https://github.com/CHERIoT-Platform/CHERIoT-RTOS
+  GIT_TAG           64d846091a43053fbdd0312fb9419e05429109c6
 )
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)


### PR DESCRIPTION
The repository and tag were inadvertently modified with an earlier commit and now prevent the software from building; switch back to upstream repo.