### PR TITLE
Update lowrisc_sonata to lowRISC/sonata-system@cc78ef2

### DIFF
--- a/hw/vendor/lowrisc_sonata.lock.hjson
+++ b/hw/vendor/lowrisc_sonata.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/sonata-system
-    rev: 736837cda6de2d7b6dbbe86a513d18d2eb4155e2
+    rev: cc78ef286b5c797176ec3342d9d0b4e4e7077ee8
   }
 }

--- a/hw/vendor/lowrisc_sonata/rtl/ip/rev_ctl/rtl/rev_ctl.sv
+++ b/hw/vendor/lowrisc_sonata/rtl/ip/rev_ctl/rtl/rev_ctl.sv
@@ -24,6 +24,10 @@ module rev_ctl import rev_ctl_reg_pkg::*; (
   // Internal registers.
   logic go;
 
+  // Internal wires.
+  logic done;
+  assign done = reg2hw.epoch.running.q & ~core_to_ctl_i[0];
+
   // Architectural registers.
   logic interrupt_status;
 
@@ -45,10 +49,6 @@ module rev_ctl import rev_ctl_reg_pkg::*; (
       end
     end
   end
-
-  // Internal wires.
-  logic done;
-  assign done = reg2hw.epoch.running.q & ~core_to_ctl_i[0];
 
   // Control to core.
   always @(posedge clk_i or negedge rst_ni) begin


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/sonata-system to revision cc78ef286b5c797176ec3342d9d0b4e4e7077ee8

* Revocation control: define done earlier (Marno van der Maas)

Closes: https://github.com/lowRISC/sunburst-chip/issues/23