### PR TITLE
Clear USBDEV packet buffer memory

### DIFF
--- a/hw/top_chip/dv/env/top_chip_dv_env_pkg.sv
+++ b/hw/top_chip/dv/env/top_chip_dv_env_pkg.sv
@@ -15,7 +15,8 @@ package top_chip_dv_env_pkg;
 
   typedef enum {
     ChipMemSRAM,
-    ChipMemROM
+    ChipMemROM,
+    ChipMemUsbdevBuf
   } chip_mem_e;
 
   localparam int unsigned NGpioPins = 32;

--- a/hw/top_chip/dv/tb/chip_hier_macros.svh
+++ b/hw/top_chip/dv/tb/chip_hier_macros.svh
@@ -8,3 +8,4 @@
 `define SRAM_MEM_HIER `SYSTEM_HIER.u_sram.u_ram.`MEM_ARRAY_SUB
 `define SRAM_CAP_MEM_HIER `SYSTEM_HIER.u_sram.u_cap_ram.`MEM_ARRAY_SUB
 `define ROM_MEM_HIER `SYSTEM_HIER.u_rom.u_rom.`MEM_ARRAY_SUB
+`define USBDEV_BUF_HIER `SYSTEM_HIER.u_usbdev.gen_no_stubbed_memory.u_memory_1p.u_mem.`MEM_ARRAY_SUB

--- a/hw/top_chip/dv/tb/tb.sv
+++ b/hw/top_chip/dv/tb/tb.sv
@@ -252,6 +252,15 @@ module top_chip_asic_tb;
         .system_base_addr    (tl_main_pkg::ADDR_SPACE_ROM));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ChipMemROM], `ROM_MEM_HIER)
 
+      `uvm_info("tb.sv", "Creating mem_bkdr_util instance for USBDEV BUFFER", UVM_MEDIUM)
+      m_mem_bkdr_util[ChipMemUsbdevBuf] = new(
+        .name  ("mem_bkdr_util[ChipMemUsbdevBuf]"),
+        .path  (`DV_STRINGIFY(`USBDEV_BUF_HIER)),
+        .depth ($size(`USBDEV_BUF_HIER)),
+        .n_bits($bits(`USBDEV_BUF_HIER)),
+        .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
+      m_mem_bkdr_util[ChipMemUsbdevBuf].clear_mem();
+
       mem = mem.first();
       do begin
         uvm_config_db#(mem_bkdr_util)::set(


### PR DESCRIPTION
To prevent X propagation causing assertions when a non-4n received packet is read from the USBDEV packet buffer memory, the memory must be initialised to have defined contents. The packet buffer only supports 32-bit accesses.