### PR TITLE
Add usbdev_aon_wake module for suspend/resume support

### DIFF
--- a/hw/top_chip/dv/verilator/top_chip_verilator.sv
+++ b/hw/top_chip/dv/verilator/top_chip_verilator.sv
@@ -130,6 +130,8 @@ module top_chip_verilator (input logic clk_i, rst_ni);
     .aon_timer_wkup_req_o(),
     .aon_timer_rst_req_o (),
 
+    .usbdev_aon_wkup_req_o(),
+
     .scanmode_i  (prim_mubi_pkg::MuBi4False),
     .ram_1p_cfg_i('0),
     .ram_2p_cfg_i('0),

--- a/hw/top_chip/rtl/top_chip_asic.sv
+++ b/hw/top_chip/rtl/top_chip_asic.sv
@@ -257,6 +257,8 @@ module top_chip_asic (
     .aon_timer_wkup_req_o(),
     .aon_timer_rst_req_o (),
 
+    .usbdev_aon_wkup_req_o(),
+
     .scanmode_i  (prim_mubi_pkg::MuBi4False),
     .ram_1p_cfg_i('0),
     .ram_2p_cfg_i('0),


### PR DESCRIPTION
This PR instantiates the usbdev_aon_wake module in the design as agreed.

Its presence has been tested with the existing USB-related top-level tests from the OT world, to check that it does not interfere with normal operation. Wiring and simulation signals have of course been inspected.

Unfortunately we do not presently have a means of testing this IP in the top level design because the DPI-side of the suspend/resume testing has not been merged into the OT repository.
It will be possible to test it on FPGA once that becomes available.


Update: to clarify, the `usbdev_aon_wake` module itself is already present, having been vendored in as part of '...ip/usbdev/rtl'