### PR TITLE
Initial Sonata XL FPGA build flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ xrun.history
 *.log
 *.fst
 *.shm
+*.jou
+*.str

--- a/hw/top_chip/fpga/data/impl_timing.xdc
+++ b/hw/top_chip/fpga/data/impl_timing.xdc
@@ -1,0 +1,5 @@
+## Copyright lowRISC contributors (Sunburst project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+
+# This file is for timing constraints to be applied *after* synthesis.

--- a/hw/top_chip/fpga/data/pins_sonata_xl.xdc
+++ b/hw/top_chip/fpga/data/pins_sonata_xl.xdc
@@ -1,0 +1,451 @@
+## Copyright lowRISC contributors (Sunburst project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+
+# This file is for physical constraints for the Sonata XL board.
+
+# Using the names in the PCB design, they should (mostly) match this file with a case-insensitive search:
+# https://github.com/newaetech/sonata-pcb/tree/main
+
+## Clocks
+set_property -dict { PACKAGE_PIN N21 IOSTANDARD LVCMOS33 } [get_ports mainClk]
+
+## Reset
+set_property -dict { PACKAGE_PIN N3 IOSTANDARD LVCMOS33 } [get_ports nrst]
+
+## General purpose LEDs
+set_property -dict { PACKAGE_PIN J14 IOSTANDARD LVCMOS33 } [get_ports usrLed0]
+set_property -dict { PACKAGE_PIN J15 IOSTANDARD LVCMOS33 } [get_ports usrLed1]
+set_property -dict { PACKAGE_PIN K16 IOSTANDARD LVCMOS33 } [get_ports usrLed2]
+set_property -dict { PACKAGE_PIN K17 IOSTANDARD LVCMOS33 } [get_ports usrLed3]
+set_property -dict { PACKAGE_PIN M14 IOSTANDARD LVCMOS33 } [get_ports usrLed4]
+set_property -dict { PACKAGE_PIN L14 IOSTANDARD LVCMOS33 } [get_ports usrLed5]
+set_property -dict { PACKAGE_PIN M15 IOSTANDARD LVCMOS33 } [get_ports usrLed6]
+set_property -dict { PACKAGE_PIN L15 IOSTANDARD LVCMOS33 } [get_ports usrLed7]
+
+## User JTAG (marked as USR_JTAG on schematic)
+set_property -dict { PACKAGE_PIN G21 IOSTANDARD LVCMOS33 } [get_ports tck_i]
+set_property -dict { PACKAGE_PIN F24 IOSTANDARD LVCMOS33 } [get_ports tms_i]
+set_property -dict { PACKAGE_PIN K23 IOSTANDARD LVCMOS33 } [get_ports td_i]
+set_property -dict { PACKAGE_PIN G24 IOSTANDARD LVCMOS33 } [get_ports td_o]
+
+## Switch and button input
+set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports usrSw0]
+set_property -dict { PACKAGE_PIN M17 IOSTANDARD LVCMOS33 } [get_ports usrSw1]
+set_property -dict { PACKAGE_PIN J19 IOSTANDARD LVCMOS33 } [get_ports usrSw2]
+set_property -dict { PACKAGE_PIN H19 IOSTANDARD LVCMOS33 } [get_ports usrSw3]
+set_property -dict { PACKAGE_PIN L17 IOSTANDARD LVCMOS33 } [get_ports usrSw4]
+set_property -dict { PACKAGE_PIN L18 IOSTANDARD LVCMOS33 } [get_ports usrSw5]
+set_property -dict { PACKAGE_PIN K20 IOSTANDARD LVCMOS33 } [get_ports usrSw6]
+set_property -dict { PACKAGE_PIN J20 IOSTANDARD LVCMOS33 } [get_ports usrSw7]
+set_property -dict { PACKAGE_PIN J8  IOSTANDARD LVCMOS18 } [get_ports navSw_0]
+set_property -dict { PACKAGE_PIN F8  IOSTANDARD LVCMOS18 } [get_ports navSw_1]
+set_property -dict { PACKAGE_PIN F7  IOSTANDARD LVCMOS18 } [get_ports navSw_2]
+set_property -dict { PACKAGE_PIN H9  IOSTANDARD LVCMOS18 } [get_ports navSw_3]
+set_property -dict { PACKAGE_PIN G9  IOSTANDARD LVCMOS18 } [get_ports navSw_4]
+set_property -dict { PACKAGE_PIN F5  IOSTANDARD LVCMOS18 } [get_ports selSw0]
+set_property -dict { PACKAGE_PIN E5  IOSTANDARD LVCMOS18 } [get_ports selSw1]
+set_property -dict { PACKAGE_PIN D5  IOSTANDARD LVCMOS18 } [get_ports selSw2]
+set_property PULLTYPE PULLUP [get_ports usrSw*]
+set_property PULLTYPE PULLUP [get_ports navSw*]
+set_property PULLTYPE PULLUP [get_ports selSw*]
+
+## CHERI error LEDs
+set_property -dict { PACKAGE_PIN N8  IOSTANDARD LVCMOS33 } [get_ports cheriErr0]
+set_property -dict { PACKAGE_PIN K3  IOSTANDARD LVCMOS33 } [get_ports cheriErr1]
+set_property -dict { PACKAGE_PIN J3  IOSTANDARD LVCMOS33 } [get_ports cheriErr2]
+set_property -dict { PACKAGE_PIN M7  IOSTANDARD LVCMOS33 } [get_ports cheriErr3]
+set_property -dict { PACKAGE_PIN L7  IOSTANDARD LVCMOS33 } [get_ports cheriErr4]
+set_property -dict { PACKAGE_PIN M4  IOSTANDARD LVCMOS33 } [get_ports cheriErr5]
+set_property -dict { PACKAGE_PIN L4  IOSTANDARD LVCMOS33 } [get_ports cheriErr6]
+set_property -dict { PACKAGE_PIN L5  IOSTANDARD LVCMOS33 } [get_ports cheriErr7]
+set_property -dict { PACKAGE_PIN K5  IOSTANDARD LVCMOS33 } [get_ports cheriErr8]
+
+## USRUSB interface
+set_property -dict { PACKAGE_PIN C3  IOSTANDARD LVCMOS18 } [get_ports usrusb_spd]
+set_property -dict { PACKAGE_PIN C2  IOSTANDARD LVCMOS18 } [get_ports usrusb_v_p]
+set_property -dict { PACKAGE_PIN B2  IOSTANDARD LVCMOS18 } [get_ports usrusb_v_n]
+set_property -dict { PACKAGE_PIN A3  IOSTANDARD LVCMOS18 } [get_ports usrusb_vpo]
+set_property -dict { PACKAGE_PIN A2  IOSTANDARD LVCMOS18 } [get_ports usrusb_vmo]
+set_property -dict { PACKAGE_PIN C1  IOSTANDARD LVCMOS18 } [get_ports usrusb_rcv]
+set_property -dict { PACKAGE_PIN B1  IOSTANDARD LVCMOS18 } [get_ports usrusb_softcn]
+set_property -dict { PACKAGE_PIN F2  IOSTANDARD LVCMOS18 } [get_ports usrusb_oe]
+set_property -dict { PACKAGE_PIN E1  IOSTANDARD LVCMOS18 } [get_ports usrusb_sus]
+set_property -dict { PACKAGE_PIN D1  IOSTANDARD LVCMOS18 } [get_ports usrusb_vbusdetect]
+
+## PMOD0
+set_property -dict { PACKAGE_PIN G22 IOSTANDARD LVCMOS33 } [get_ports pmod0_1]
+set_property -dict { PACKAGE_PIN H23 IOSTANDARD LVCMOS33 } [get_ports pmod0_2]
+set_property -dict { PACKAGE_PIN J23 IOSTANDARD LVCMOS33 } [get_ports pmod0_3]
+set_property -dict { PACKAGE_PIN F22 IOSTANDARD LVCMOS33 } [get_ports pmod0_4]
+set_property -dict { PACKAGE_PIN E23 IOSTANDARD LVCMOS33 } [get_ports pmod0_5]
+set_property -dict { PACKAGE_PIN H24 IOSTANDARD LVCMOS33 } [get_ports pmod0_6]
+set_property -dict { PACKAGE_PIN J24 IOSTANDARD LVCMOS33 } [get_ports pmod0_7]
+set_property -dict { PACKAGE_PIN F23 IOSTANDARD LVCMOS33 } [get_ports pmod0_8]
+
+## PMODC (pins between PMOD0 and PMOD1 on shared connector)
+set_property -dict { PACKAGE_PIN J25 IOSTANDARD LVCMOS33 } [get_ports pmodc_1]
+set_property -dict { PACKAGE_PIN J26 IOSTANDARD LVCMOS33 } [get_ports pmodc_2]
+set_property -dict { PACKAGE_PIN L19 IOSTANDARD LVCMOS33 } [get_ports pmodc_3]
+set_property -dict { PACKAGE_PIN F25 IOSTANDARD LVCMOS33 } [get_ports pmodc_4]
+set_property -dict { PACKAGE_PIN G26 IOSTANDARD LVCMOS33 } [get_ports pmodc_5]
+set_property -dict { PACKAGE_PIN G25 IOSTANDARD LVCMOS33 } [get_ports pmodc_6]
+
+## PMOD1
+set_property -dict { PACKAGE_PIN J18 IOSTANDARD LVCMOS33 } [get_ports pmod1_1]
+set_property -dict { PACKAGE_PIN H18 IOSTANDARD LVCMOS33 } [get_ports pmod1_2]
+set_property -dict { PACKAGE_PIN G20 IOSTANDARD LVCMOS33 } [get_ports pmod1_3]
+set_property -dict { PACKAGE_PIN K22 IOSTANDARD LVCMOS33 } [get_ports pmod1_4]
+set_property -dict { PACKAGE_PIN K21 IOSTANDARD LVCMOS33 } [get_ports pmod1_5]
+set_property -dict { PACKAGE_PIN J21 IOSTANDARD LVCMOS33 } [get_ports pmod1_6]
+set_property -dict { PACKAGE_PIN H21 IOSTANDARD LVCMOS33 } [get_ports pmod1_7]
+set_property -dict { PACKAGE_PIN H22 IOSTANDARD LVCMOS33 } [get_ports pmod1_8]
+
+## Status LEDs
+set_property -dict { PACKAGE_PIN N7  IOSTANDARD LVCMOS33 } [get_ports led_legacy]
+set_property -dict { PACKAGE_PIN N6  IOSTANDARD LVCMOS33 } [get_ports led_cheri]
+set_property -dict { PACKAGE_PIN M6  IOSTANDARD LVCMOS33 } [get_ports led_halted]
+set_property -dict { PACKAGE_PIN M5  IOSTANDARD LVCMOS33 } [get_ports led_bootok]
+
+## LCD display
+set_property -dict { PACKAGE_PIN P6  IOSTANDARD LVCMOS33 } [get_ports lcd_rst]
+set_property -dict { PACKAGE_PIN L3  IOSTANDARD LVCMOS33 } [get_ports lcd_dc]
+set_property -dict { PACKAGE_PIN M2  IOSTANDARD LVCMOS33 } [get_ports lcd_copi]
+set_property -dict { PACKAGE_PIN P5  IOSTANDARD LVCMOS33 } [get_ports lcd_clk]
+set_property -dict { PACKAGE_PIN P3  IOSTANDARD LVCMOS33 } [get_ports lcd_cs]
+set_property -dict { PACKAGE_PIN R3  IOSTANDARD LVCMOS33 } [get_ports lcd_backlight]
+
+## UART 0
+set_property -dict { PACKAGE_PIN D25 IOSTANDARD LVCMOS33 } [get_ports ser0_tx]
+set_property -dict { PACKAGE_PIN D26 IOSTANDARD LVCMOS33 } [get_ports ser0_rx]
+
+## UART 1
+set_property -dict { PACKAGE_PIN E26 IOSTANDARD LVCMOS33 } [get_ports ser1_tx]
+set_property -dict { PACKAGE_PIN H26 IOSTANDARD LVCMOS33 } [get_ports ser1_rx]
+
+## UART RS-232
+set_property -dict { PACKAGE_PIN N4  IOSTANDARD LVCMOS33 } [get_ports rs232_tx]
+set_property -dict { PACKAGE_PIN U1  IOSTANDARD LVCMOS33 } [get_ports rs232_rx]
+
+## UART RS-485
+set_property -dict { PACKAGE_PIN P1  IOSTANDARD LVCMOS33 } [get_ports rs485_ro]
+set_property -dict { PACKAGE_PIN T4  IOSTANDARD LVCMOS33 } [get_ports rs485_de]
+set_property -dict { PACKAGE_PIN T3  IOSTANDARD LVCMOS33 } [get_ports rs485_ren]
+set_property -dict { PACKAGE_PIN U2  IOSTANDARD LVCMOS33 } [get_ports rs485_di]
+
+## QWIIC and Arduino Shield
+set_property -dict { PACKAGE_PIN R8 IOSTANDARD LVCMOS33 } [get_ports sda0]
+set_property -dict { PACKAGE_PIN U5 IOSTANDARD LVCMOS33 } [get_ports scl0]
+
+## QWIIC
+set_property -dict { PACKAGE_PIN T5 IOSTANDARD LVCMOS33 } [get_ports sda1]
+set_property -dict { PACKAGE_PIN U6 IOSTANDARD LVCMOS33 } [get_ports scl1]
+
+## mikroBUS Click
+## Reset (connected to GPO)
+set_property -dict { PACKAGE_PIN R1  IOSTANDARD LVCMOS33 } [get_ports mb0]
+## SPI chip select
+set_property -dict { PACKAGE_PIN T2  IOSTANDARD LVCMOS33 } [get_ports mb1]
+## SPI SCLK
+set_property -dict { PACKAGE_PIN R2  IOSTANDARD LVCMOS33 } [get_ports mb2]
+## SPI CIPO
+set_property -dict { PACKAGE_PIN K1  IOSTANDARD LVCMOS33 } [get_ports mb3]
+## SPI COPI
+set_property -dict { PACKAGE_PIN L2  IOSTANDARD LVCMOS33 } [get_ports mb4]
+## I2C SDA
+set_property -dict { PACKAGE_PIN J1  IOSTANDARD LVCMOS33 } [get_ports mb5]
+## I2C SCL
+set_property -dict { PACKAGE_PIN N1  IOSTANDARD LVCMOS33 } [get_ports mb6]
+## Enable pull-ups because this I2C bus will often be undriven externally.
+set_property PULLTYPE PULLUP [get_ports mb5]
+set_property PULLTYPE PULLUP [get_ports mb6]
+## UART TX
+set_property -dict { PACKAGE_PIN M1  IOSTANDARD LVCMOS33 } [get_ports mb7]
+## UART RX
+set_property -dict { PACKAGE_PIN U4  IOSTANDARD LVCMOS33 } [get_ports mb8]
+## Interrupt (connected to GPI)
+set_property -dict { PACKAGE_PIN R6  IOSTANDARD LVCMOS33 } [get_ports mb9]
+## PWM
+set_property -dict { PACKAGE_PIN R5  IOSTANDARD LVCMOS33 } [get_ports mb10]
+
+## R-Pi Header
+
+## GPIO/SPI1 bus
+set_property -dict { PACKAGE_PIN T25 IOSTANDARD LVCMOS33 } [get_ports rph_g21_sclk]
+set_property -dict { PACKAGE_PIN R23 IOSTANDARD LVCMOS33 } [get_ports rph_g20_copi]
+set_property -dict { PACKAGE_PIN P26 IOSTANDARD LVCMOS33 } [get_ports rph_g19_cipo]
+## SPI1 CE0
+set_property -dict { PACKAGE_PIN L25 IOSTANDARD LVCMOS33 } [get_ports rph_g18]
+## SPI1 CE1
+set_property -dict { PACKAGE_PIN N14 IOSTANDARD LVCMOS33 } [get_ports rph_g17]
+set_property -dict { PACKAGE_PIN T23 IOSTANDARD LVCMOS33 } [get_ports rph_g16_ce2]
+
+## GPIO/SPI0 bus
+set_property -dict { PACKAGE_PIN M21 IOSTANDARD LVCMOS33 } [get_ports rph_g11_sclk]
+set_property -dict { PACKAGE_PIN N19 IOSTANDARD LVCMOS33 } [get_ports rph_g10_copi]
+set_property -dict { PACKAGE_PIN R21 IOSTANDARD LVCMOS33 } [get_ports rph_g9_cipo]
+set_property -dict { PACKAGE_PIN P19 IOSTANDARD LVCMOS33 } [get_ports rph_g8_ce0]
+set_property -dict { PACKAGE_PIN M19 IOSTANDARD LVCMOS33 } [get_ports rph_g7_ce1]
+
+## GPIO/I2C bus
+set_property -dict { PACKAGE_PIN P18 IOSTANDARD LVCMOS33 } [get_ports rph_g2_sda]
+set_property -dict { PACKAGE_PIN M24 IOSTANDARD LVCMOS33 } [get_ports rph_g3_scl]
+
+## UART
+set_property -dict { PACKAGE_PIN R14 IOSTANDARD LVCMOS33 } [get_ports rph_txd0]
+set_property -dict { PACKAGE_PIN N16 IOSTANDARD LVCMOS33 } [get_ports rph_rxd0]
+
+## Other GPIO
+set_property -dict { PACKAGE_PIN L22 IOSTANDARD LVCMOS33 } [get_ports rph_g4]
+set_property -dict { PACKAGE_PIN T22 IOSTANDARD LVCMOS33 } [get_ports rph_g5]
+set_property -dict { PACKAGE_PIN R26 IOSTANDARD LVCMOS33 } [get_ports rph_g6]
+set_property -dict { PACKAGE_PIN T24 IOSTANDARD LVCMOS33 } [get_ports rph_g12]
+set_property -dict { PACKAGE_PIN R17 IOSTANDARD LVCMOS33 } [get_ports rph_g13]
+set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports rph_g22]
+set_property -dict { PACKAGE_PIN M20 IOSTANDARD LVCMOS33 } [get_ports rph_g23]
+set_property -dict { PACKAGE_PIN L23 IOSTANDARD LVCMOS33 } [get_ports rph_g24]
+set_property -dict { PACKAGE_PIN P15 IOSTANDARD LVCMOS33 } [get_ports rph_g25]
+set_property -dict { PACKAGE_PIN N22 IOSTANDARD LVCMOS33 } [get_ports rph_g26]
+set_property -dict { PACKAGE_PIN P14 IOSTANDARD LVCMOS33 } [get_ports rph_g27]
+
+## ID_SC/SD - I2C bus for HAT ID EEPROM; pull-ups are on the HAT itself
+set_property -dict { PACKAGE_PIN P21 IOSTANDARD LVCMOS33 } [get_ports rph_g1] ;# ID_SC
+set_property -dict { PACKAGE_PIN P23 IOSTANDARD LVCMOS33 } [get_ports rph_g0] ;# ID_SD
+## Enable pull-ups because this I2C bus will often be undriven externally.
+set_property PULLTYPE PULLUP [get_ports rph_g1]
+set_property PULLTYPE PULLUP [get_ports rph_g0]
+
+## Arduino/AVR In-Circuit Serial Programming (ICSP) header
+set_property -dict { PACKAGE_PIN N18 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio17]
+set_property -dict { PACKAGE_PIN L24 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio16]
+set_property -dict { PACKAGE_PIN L20 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio15]
+set_property -dict { PACKAGE_PIN K25 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio14]
+
+## Arduino Shield
+## SPI SCLK
+set_property -dict { PACKAGE_PIN M22 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio13]
+## SPI CIPO
+set_property -dict { PACKAGE_PIN N23 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio12]
+## SPI COPI
+set_property -dict { PACKAGE_PIN K26 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio11]
+## SPI chip select
+set_property -dict { PACKAGE_PIN R20 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio10]
+## GPIO
+set_property -dict { PACKAGE_PIN N24 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio9]
+set_property -dict { PACKAGE_PIN P24 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio8]
+set_property -dict { PACKAGE_PIN N17 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio7]
+set_property -dict { PACKAGE_PIN P25 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio6]
+set_property -dict { PACKAGE_PIN M26 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio5]
+set_property -dict { PACKAGE_PIN R18 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio4]
+set_property -dict { PACKAGE_PIN R22 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio3]
+set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio2]
+set_property -dict { PACKAGE_PIN N26 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio1]
+set_property -dict { PACKAGE_PIN R25 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio0]
+## Digital inputs from analog(ue) pins via 1k resistor
+set_property -dict { PACKAGE_PIN K18 IOSTANDARD LVCMOS33 } [get_ports analog0_digital]
+set_property -dict { PACKAGE_PIN K15 IOSTANDARD LVCMOS33 } [get_ports analog1_digital]
+set_property -dict { PACKAGE_PIN J16 IOSTANDARD LVCMOS33 } [get_ports analog2_digital]
+set_property -dict { PACKAGE_PIN E17 IOSTANDARD LVCMOS33 } [get_ports analog3_digital]
+set_property -dict { PACKAGE_PIN E18 IOSTANDARD LVCMOS33 } [get_ports analog4_digital]
+set_property -dict { PACKAGE_PIN D18 IOSTANDARD LVCMOS33 } [get_ports analog5_digital]
+## Analog(ue) input pairs from analog(ue) pins via buffer and impedance network
+## UG480: "...an IOSTANDARD must be selected that is compatible for the bank
+##         even though the IOSTANDARD does not affect the input programming."
+set_property -dict { PACKAGE_PIN E6  IOSTANDARD LVCMOS18 } [get_ports analog0_p] ;# VAUX4P
+set_property -dict { PACKAGE_PIN D6  IOSTANDARD LVCMOS18 } [get_ports analog0_n] ;# VAUX4N,
+set_property -dict { PACKAGE_PIN H8  IOSTANDARD LVCMOS18 } [get_ports analog1_p] ;# VAUX12P
+set_property -dict { PACKAGE_PIN G8  IOSTANDARD LVCMOS18 } [get_ports analog1_n] ;# VAUX12N
+set_property -dict { PACKAGE_PIN H7  IOSTANDARD LVCMOS18 } [get_ports analog2_p] ;# VAUX5P
+set_property -dict { PACKAGE_PIN G7  IOSTANDARD LVCMOS18 } [get_ports analog2_n] ;# VAUX5N
+set_property -dict { PACKAGE_PIN H6  IOSTANDARD LVCMOS18 } [get_ports analog3_p] ;# VAUX13P
+set_property -dict { PACKAGE_PIN G6  IOSTANDARD LVCMOS18 } [get_ports analog3_n] ;# VAUX13N
+set_property -dict { PACKAGE_PIN J6  IOSTANDARD LVCMOS18 } [get_ports analog4_p] ;# VAUX6P
+set_property -dict { PACKAGE_PIN J5  IOSTANDARD LVCMOS18 } [get_ports analog4_n] ;# VAUX6N
+set_property -dict { PACKAGE_PIN L8  IOSTANDARD LVCMOS18 } [get_ports analog5_p] ;# VAUX14P
+set_property -dict { PACKAGE_PIN K8  IOSTANDARD LVCMOS18 } [get_ports analog5_n] ;# VAUX14N
+
+## RGB LED
+set_property -dict { PACKAGE_PIN G16 IOSTANDARD LVCMOS33 } [get_ports rgbled0]
+set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports rgbled_en]
+
+## SPI Flash
+set_property -dict { PACKAGE_PIN D19 IOSTANDARD LVCMOS33 } [get_ports appspi_clk]
+set_property -dict { PACKAGE_PIN C19 IOSTANDARD LVCMOS33 } [get_ports appspi_d0]
+set_property -dict { PACKAGE_PIN E20 IOSTANDARD LVCMOS33 } [get_ports appspi_d1]
+set_property -dict { PACKAGE_PIN D20 IOSTANDARD LVCMOS33 } [get_ports appspi_d2]
+set_property -dict { PACKAGE_PIN B20 IOSTANDARD LVCMOS33 } [get_ports appspi_d3]
+set_property -dict { PACKAGE_PIN A20 IOSTANDARD LVCMOS33 } [get_ports appspi_cs]
+set_property PULLTYPE PULLUP [get_ports appspi_d1]
+
+## Ethernet MAC
+set_property -dict { PACKAGE_PIN H3  IOSTANDARD LVCMOS18 } [get_ports ethmac_rst]
+set_property -dict { PACKAGE_PIN G4  IOSTANDARD LVCMOS18 } [get_ports ethmac_copi]
+set_property -dict { PACKAGE_PIN G5  IOSTANDARD LVCMOS18 } [get_ports ethmac_sclk]
+set_property -dict { PACKAGE_PIN F4  IOSTANDARD LVCMOS18 } [get_ports ethmac_cipo]
+set_property -dict { PACKAGE_PIN G2  IOSTANDARD LVCMOS18 } [get_ports ethmac_intr]
+set_property PULLTYPE PULLUP [get_ports ethmac_intr]
+set_property -dict { PACKAGE_PIN G1  IOSTANDARD LVCMOS18 } [get_ports ethmac_cs]
+
+## MicroSD card slot
+set_property -dict { PACKAGE_PIN P8  IOSTANDARD LVCMOS33 } [get_ports microsd_clk]
+set_property -dict { PACKAGE_PIN H1  IOSTANDARD LVCMOS33 } [get_ports microsd_dat0]
+# set_property -dict { PACKAGE_PIN R7  IOSTANDARD LVCMOS33 } [get_ports microsd_dat1] // unused in SPI bus mode
+# set_property -dict { PACKAGE_PIN H2  IOSTANDARD LVCMOS33 } [get_ports microsd_dat2] // unused in SPI bus mode
+set_property -dict { PACKAGE_PIN T7  IOSTANDARD LVCMOS33 } [get_ports microsd_dat3]
+set_property -dict { PACKAGE_PIN T8  IOSTANDARD LVCMOS33 } [get_ports microsd_cmd]
+set_property -dict { PACKAGE_PIN K7  IOSTANDARD LVCMOS18 } [get_ports microsd_det]
+
+# HyperRAM
+# No HyperRAM on Sonata XL
+
+## XL expansion headers
+set_property -dict { PACKAGE_PIN AE5  IOSTANDARD LVCMOS33 } [get_ports ex0_0]
+set_property -dict { PACKAGE_PIN V9   IOSTANDARD LVCMOS33 } [get_ports ex0_1]
+set_property -dict { PACKAGE_PIN AF5  IOSTANDARD LVCMOS33 } [get_ports ex0_2]
+set_property -dict { PACKAGE_PIN V8   IOSTANDARD LVCMOS33 } [get_ports ex0_3]
+set_property -dict { PACKAGE_PIN AD5  IOSTANDARD LVCMOS33 } [get_ports ex0_4]
+set_property -dict { PACKAGE_PIN U7   IOSTANDARD LVCMOS33 } [get_ports ex0_5]
+set_property -dict { PACKAGE_PIN AF4  IOSTANDARD LVCMOS33 } [get_ports ex0_6]
+set_property -dict { PACKAGE_PIN V7   IOSTANDARD LVCMOS33 } [get_ports ex0_7]
+set_property -dict { PACKAGE_PIN AF3  IOSTANDARD LVCMOS33 } [get_ports ex0_8]
+set_property -dict { PACKAGE_PIN Y8   IOSTANDARD LVCMOS33 } [get_ports ex0_9]
+set_property -dict { PACKAGE_PIN AE3  IOSTANDARD LVCMOS33 } [get_ports ex0_10]
+set_property -dict { PACKAGE_PIN AA8  IOSTANDARD LVCMOS33 } [get_ports ex0_11]
+set_property -dict { PACKAGE_PIN AF2  IOSTANDARD LVCMOS33 } [get_ports ex0_12]
+set_property -dict { PACKAGE_PIN V6   IOSTANDARD LVCMOS33 } [get_ports ex0_13]
+set_property -dict { PACKAGE_PIN AE2  IOSTANDARD LVCMOS33 } [get_ports ex0_14]
+set_property -dict { PACKAGE_PIN AA7  IOSTANDARD LVCMOS33 } [get_ports ex0_15]
+set_property -dict { PACKAGE_PIN AE1  IOSTANDARD LVCMOS33 } [get_ports ex0_16]
+set_property -dict { PACKAGE_PIN W6   IOSTANDARD LVCMOS33 } [get_ports ex0_17]
+set_property -dict { PACKAGE_PIN AD1  IOSTANDARD LVCMOS33 } [get_ports ex0_18]
+set_property -dict { PACKAGE_PIN AC6  IOSTANDARD LVCMOS33 } [get_ports ex0_19]
+set_property -dict { PACKAGE_PIN AC2  IOSTANDARD LVCMOS33 } [get_ports ex0_20]
+set_property -dict { PACKAGE_PIN AB5  IOSTANDARD LVCMOS33 } [get_ports ex0_21]
+set_property -dict { PACKAGE_PIN AC1  IOSTANDARD LVCMOS33 } [get_ports ex0_22]
+set_property -dict { PACKAGE_PIN AC4  IOSTANDARD LVCMOS33 } [get_ports ex0_23]
+set_property -dict { PACKAGE_PIN AB2  IOSTANDARD LVCMOS33 } [get_ports ex0_24]
+set_property -dict { PACKAGE_PIN AD4  IOSTANDARD LVCMOS33 } [get_ports ex0_25]
+set_property -dict { PACKAGE_PIN AB1  IOSTANDARD LVCMOS33 } [get_ports ex0_26]
+set_property -dict { PACKAGE_PIN W1   IOSTANDARD LVCMOS33 } [get_ports ex0_27]
+set_property -dict { PACKAGE_PIN AA2  IOSTANDARD LVCMOS33 } [get_ports ex0_28]
+set_property -dict { PACKAGE_PIN V1   IOSTANDARD LVCMOS33 } [get_ports ex0_29]
+set_property -dict { PACKAGE_PIN V4   IOSTANDARD LVCMOS33 } [get_ports ex0_30]
+set_property -dict { PACKAGE_PIN AD3  IOSTANDARD LVCMOS33 } [get_ports ex0_31]
+set_property -dict { PACKAGE_PIN Y1   IOSTANDARD LVCMOS33 } [get_ports ex0_32]
+set_property -dict { PACKAGE_PIN AC3  IOSTANDARD LVCMOS33 } [get_ports ex0_33]
+set_property -dict { PACKAGE_PIN AB4  IOSTANDARD LVCMOS33 } [get_ports ex0_34]
+set_property -dict { PACKAGE_PIN AA5  IOSTANDARD LVCMOS33 } [get_ports ex0_35]
+set_property -dict { PACKAGE_PIN V3   IOSTANDARD LVCMOS33 } [get_ports ex0_36]
+set_property -dict { PACKAGE_PIN AA4  IOSTANDARD LVCMOS33 } [get_ports ex0_37]
+set_property -dict { PACKAGE_PIN Y2   IOSTANDARD LVCMOS33 } [get_ports ex0_38]
+set_property -dict { PACKAGE_PIN AA3  IOSTANDARD LVCMOS33 } [get_ports ex0_39]
+set_property -dict { PACKAGE_PIN V2   IOSTANDARD LVCMOS33 } [get_ports ex0_40]
+set_property -dict { PACKAGE_PIN Y6   IOSTANDARD LVCMOS33 } [get_ports ex0_41]
+set_property -dict { PACKAGE_PIN Y5   IOSTANDARD LVCMOS33 } [get_ports ex0_42]
+set_property -dict { PACKAGE_PIN Y3   IOSTANDARD LVCMOS33 } [get_ports ex0_43]
+set_property -dict { PACKAGE_PIN AB6  IOSTANDARD LVCMOS33 } [get_ports ex0_44]
+set_property -dict { PACKAGE_PIN W5   IOSTANDARD LVCMOS33 } [get_ports ex0_45]
+set_property -dict { PACKAGE_PIN Y7   IOSTANDARD LVCMOS33 } [get_ports ex0_46]
+set_property -dict { PACKAGE_PIN W3   IOSTANDARD LVCMOS33 } [get_ports ex0_47]
+set_property -dict { PACKAGE_PIN W8   IOSTANDARD LVCMOS33 } [get_ports ex0_48]
+set_property -dict { PACKAGE_PIN W4   IOSTANDARD LVCMOS33 } [get_ports ex0_49]
+set_property -dict { PACKAGE_PIN AC19 IOSTANDARD LVCMOS33 } [get_ports ex0_50]
+set_property -dict { PACKAGE_PIN AD26 IOSTANDARD LVCMOS33 } [get_ports ex0_51]
+set_property -dict { PACKAGE_PIN AC18 IOSTANDARD LVCMOS33 } [get_ports ex0_52]
+set_property -dict { PACKAGE_PIN AD25 IOSTANDARD LVCMOS33 } [get_ports ex0_53]
+set_property -dict { PACKAGE_PIN AB19 IOSTANDARD LVCMOS33 } [get_ports ex0_54]
+set_property -dict { PACKAGE_PIN AB21 IOSTANDARD LVCMOS33 } [get_ports ex0_55]
+set_property -dict { PACKAGE_PIN AB20 IOSTANDARD LVCMOS33 } [get_ports ex0_56]
+set_property -dict { PACKAGE_PIN AF18 IOSTANDARD LVCMOS33 } [get_ports ex0_57]
+set_property -dict { PACKAGE_PIN AD19 IOSTANDARD LVCMOS33 } [get_ports ex0_58]
+set_property -dict { PACKAGE_PIN AD20 IOSTANDARD LVCMOS33 } [get_ports ex0_59]
+set_property -dict { PACKAGE_PIN AA20 IOSTANDARD LVCMOS33 } [get_ports ex0_60]
+set_property -dict { PACKAGE_PIN AA19 IOSTANDARD LVCMOS33 } [get_ports ex0_61]
+set_property -dict { PACKAGE_PIN AE18 IOSTANDARD LVCMOS33 } [get_ports ex0_62]
+set_property -dict { PACKAGE_PIN AE20 IOSTANDARD LVCMOS33 } [get_ports ex0_63]
+set_property -dict { PACKAGE_PIN T17  IOSTANDARD LVCMOS33 } [get_ports ex1_0]
+set_property -dict { PACKAGE_PIN T15  IOSTANDARD LVCMOS33 } [get_ports ex1_1]
+set_property -dict { PACKAGE_PIN T19  IOSTANDARD LVCMOS33 } [get_ports ex1_2]
+set_property -dict { PACKAGE_PIN T18  IOSTANDARD LVCMOS33 } [get_ports ex1_3]
+set_property -dict { PACKAGE_PIN T20  IOSTANDARD LVCMOS33 } [get_ports ex1_4]
+set_property -dict { PACKAGE_PIN V16  IOSTANDARD LVCMOS33 } [get_ports ex1_5]
+set_property -dict { PACKAGE_PIN U19  IOSTANDARD LVCMOS33 } [get_ports ex1_6]
+set_property -dict { PACKAGE_PIN V17  IOSTANDARD LVCMOS33 } [get_ports ex1_7]
+set_property -dict { PACKAGE_PIN U21  IOSTANDARD LVCMOS33 } [get_ports ex1_8]
+set_property -dict { PACKAGE_PIN W18  IOSTANDARD LVCMOS33 } [get_ports ex1_9]
+set_property -dict { PACKAGE_PIN V22  IOSTANDARD LVCMOS33 } [get_ports ex1_10]
+set_property -dict { PACKAGE_PIN Y23  IOSTANDARD LVCMOS33 } [get_ports ex1_11]
+set_property -dict { PACKAGE_PIN W20  IOSTANDARD LVCMOS33 } [get_ports ex1_12]
+set_property -dict { PACKAGE_PIN AA24 IOSTANDARD LVCMOS33 } [get_ports ex1_13]
+set_property -dict { PACKAGE_PIN V14  IOSTANDARD LVCMOS33 } [get_ports ex1_14]
+set_property -dict { PACKAGE_PIN AA23 IOSTANDARD LVCMOS33 } [get_ports ex1_15]
+set_property -dict { PACKAGE_PIN U16  IOSTANDARD LVCMOS33 } [get_ports ex1_16]
+set_property -dict { PACKAGE_PIN AB24 IOSTANDARD LVCMOS33 } [get_ports ex1_17]
+set_property -dict { PACKAGE_PIN U17  IOSTANDARD LVCMOS33 } [get_ports ex1_18]
+set_property -dict { PACKAGE_PIN AC24 IOSTANDARD LVCMOS33 } [get_ports ex1_19]
+set_property -dict { PACKAGE_PIN V18  IOSTANDARD LVCMOS33 } [get_ports ex1_20]
+set_property -dict { PACKAGE_PIN AA22 IOSTANDARD LVCMOS33 } [get_ports ex1_21]
+set_property -dict { PACKAGE_PIN V19  IOSTANDARD LVCMOS33 } [get_ports ex1_22]
+set_property -dict { PACKAGE_PIN U15  IOSTANDARD LVCMOS33 } [get_ports ex1_23]
+set_property -dict { PACKAGE_PIN W19  IOSTANDARD LVCMOS33 } [get_ports ex1_24]
+set_property -dict { PACKAGE_PIN T14  IOSTANDARD LVCMOS33 } [get_ports ex1_25]
+set_property -dict { PACKAGE_PIN U26  IOSTANDARD LVCMOS33 } [get_ports ex1_26]
+set_property -dict { PACKAGE_PIN U25  IOSTANDARD LVCMOS33 } [get_ports ex1_27]
+set_property -dict { PACKAGE_PIN V26  IOSTANDARD LVCMOS33 } [get_ports ex1_28]
+set_property -dict { PACKAGE_PIN W26  IOSTANDARD LVCMOS33 } [get_ports ex1_29]
+set_property -dict { PACKAGE_PIN W25  IOSTANDARD LVCMOS33 } [get_ports ex1_30]
+set_property -dict { PACKAGE_PIN V21  IOSTANDARD LVCMOS33 } [get_ports ex1_31]
+set_property -dict { PACKAGE_PIN Y26  IOSTANDARD LVCMOS33 } [get_ports ex1_32]
+set_property -dict { PACKAGE_PIN W21  IOSTANDARD LVCMOS33 } [get_ports ex1_33]
+set_property -dict { PACKAGE_PIN U22  IOSTANDARD LVCMOS33 } [get_ports ex1_34]
+set_property -dict { PACKAGE_PIN U24  IOSTANDARD LVCMOS33 } [get_ports ex1_35]
+set_property -dict { PACKAGE_PIN Y25  IOSTANDARD LVCMOS33 } [get_ports ex1_36]
+set_property -dict { PACKAGE_PIN V23  IOSTANDARD LVCMOS33 } [get_ports ex1_37]
+set_property -dict { PACKAGE_PIN AA25 IOSTANDARD LVCMOS33 } [get_ports ex1_38]
+set_property -dict { PACKAGE_PIN V24  IOSTANDARD LVCMOS33 } [get_ports ex1_39]
+set_property -dict { PACKAGE_PIN AB26 IOSTANDARD LVCMOS33 } [get_ports ex1_40]
+set_property -dict { PACKAGE_PIN W23  IOSTANDARD LVCMOS33 } [get_ports ex1_41]
+set_property -dict { PACKAGE_PIN AB25 IOSTANDARD LVCMOS33 } [get_ports ex1_42]
+set_property -dict { PACKAGE_PIN W24  IOSTANDARD LVCMOS33 } [get_ports ex1_43]
+set_property -dict { PACKAGE_PIN AC26 IOSTANDARD LVCMOS33 } [get_ports ex1_44]
+set_property -dict { PACKAGE_PIN Y22  IOSTANDARD LVCMOS33 } [get_ports ex1_45]
+set_property -dict { PACKAGE_PIN U14  IOSTANDARD LVCMOS33 } [get_ports ex1_46]
+set_property -dict { PACKAGE_PIN Y21  IOSTANDARD LVCMOS33 } [get_ports ex1_47]
+set_property -dict { PACKAGE_PIN U20  IOSTANDARD LVCMOS33 } [get_ports ex1_48]
+set_property -dict { PACKAGE_PIN Y20  IOSTANDARD LVCMOS33 } [get_ports ex1_49]
+set_property -dict { PACKAGE_PIN AE26 IOSTANDARD LVCMOS33 } [get_ports ex1_50]
+set_property -dict { PACKAGE_PIN AB22 IOSTANDARD LVCMOS33 } [get_ports ex1_51]
+set_property -dict { PACKAGE_PIN AE25 IOSTANDARD LVCMOS33 } [get_ports ex1_52]
+set_property -dict { PACKAGE_PIN AD24 IOSTANDARD LVCMOS33 } [get_ports ex1_53]
+set_property -dict { PACKAGE_PIN AF25 IOSTANDARD LVCMOS33 } [get_ports ex1_54]
+set_property -dict { PACKAGE_PIN AC23 IOSTANDARD LVCMOS33 } [get_ports ex1_55]
+set_property -dict { PACKAGE_PIN AF24 IOSTANDARD LVCMOS33 } [get_ports ex1_56]
+set_property -dict { PACKAGE_PIN AD23 IOSTANDARD LVCMOS33 } [get_ports ex1_57]
+set_property -dict { PACKAGE_PIN AE23 IOSTANDARD LVCMOS33 } [get_ports ex1_58]
+set_property -dict { PACKAGE_PIN AC22 IOSTANDARD LVCMOS33 } [get_ports ex1_59]
+set_property -dict { PACKAGE_PIN AF23 IOSTANDARD LVCMOS33 } [get_ports ex1_60]
+set_property -dict { PACKAGE_PIN AC21 IOSTANDARD LVCMOS33 } [get_ports ex1_61]
+set_property -dict { PACKAGE_PIN AE21 IOSTANDARD LVCMOS33 } [get_ports ex1_62]
+set_property -dict { PACKAGE_PIN AD21 IOSTANDARD LVCMOS33 } [get_ports ex1_63]
+
+## Voltage and bitstream
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+
+## Clock-Domain Crossing (CDC) primitives.
+# Set DONT_TOUCH on CDC primitives to prevent pin or boundary changes that
+# could make it difficult to find and apply timing exceptions to them or
+# perform CDC/RDC analysis on them later.
+# May be able to be downgraded to KEEP_HIERARCHY, but play it safe for now.
+set_property DONT_TOUCH TRUE [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
+set_property DONT_TOUCH TRUE [get_cells -hier -filter {ORIG_REF_NAME == prim_fifo_async}]
+set_property -quiet DONT_TOUCH TRUE [get_cells -quiet -hier -filter {ORIG_REF_NAME == prim_fifo_async_simple}]
+# Set ASYNC_REG on the flops our flop-based CDC synchronisers to get
+# special place&route to reduce the MTBF from metastability, and to prevent
+# dangerous optimisations. Note, this appears NOT to include timing exceptions.
+# See the ASYNC_REG sections of UG901 or UG912 for details.
+set sync_cells [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
+set sync_clk_in [get_pins -of $sync_cells -filter {REF_PIN_NAME == clk_i}]
+set sync_flops [all_fanout -flat -only_cells -endpoints_only $sync_clk_in]
+set_property ASYNC_REG TRUE $sync_flops

--- a/hw/top_chip/fpga/data/synth_timing.xdc
+++ b/hw/top_chip/fpga/data/synth_timing.xdc
@@ -1,0 +1,133 @@
+## Copyright lowRISC contributors (Sunburst project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+
+# This file is for timing constraints to be applied *before* synthesis.
+# i.e. timing constraints on top-level ports.
+#
+# See UG949 and UG903 for information on setting various timing constraints.
+
+#### Recommended timing constraints sequence from UG949 ####
+## Timing Assertions Section
+# Primary clocks
+# Virtual clocks
+# Generated clocks
+# Delay for external MMCM/PLL feedback loop
+# Clock Uncertainty and Jitter
+# Input and output delay constraints
+# Clock Groups and Clock False Paths
+## Timing Exceptions Section
+# False Paths
+# Max Delay / Min Delay
+# Multicycle Paths
+# Case Analysis
+# Disable Timing
+
+
+#### Timing Assertions Section ####
+
+### Primary clocks ###
+create_clock -name mainClk -period 40.0   [get_ports mainClk] ;# 40 ns = 25 MHz
+# create_clock -name tck     -period 66.666 [get_ports tck_i]   ;# 66 ns = 15 MHz
+
+### Virtual clocks ###
+create_clock -name vclk_extusb -period 83.333 ;# 83 ns = 12 MHz (full-speed USB)
+
+### Generated clocks ###
+# PLL clocks - name only; period will be derived from RTL parameters.
+# All are generated from mainClk.
+set clk_sys_source_pin    [get_pins [all_fanin -flat [get_nets clk_sys]] \
+                           -filter {name =~ u_clk_rst_gen/pll/CLKOUT*}]
+set clk_peri_source_pin   [get_pins [all_fanin -flat [get_nets clk_peri]] \
+                           -filter {name =~ u_clk_rst_gen/pll/CLKOUT*}]
+set clk_usb_source_pin    [get_pins [all_fanin -flat [get_nets clk_usb]] \
+                           -filter {name =~ u_clk_rst_gen/pll/CLKOUT*}]
+set clk_aon_source_pin    [get_pins [all_fanin -flat [get_nets clk_aon]] \
+                           -filter {name =~ u_clk_rst_gen/pll/CLKOUT*}]
+create_generated_clock -name clk_sys   $clk_sys_source_pin
+create_generated_clock -name clk_peri  $clk_peri_source_pin
+create_generated_clock -name clk_usb   $clk_usb_source_pin
+create_generated_clock -name clk_aon   $clk_aon_source_pin
+# mainClk and internal clocks generated from it (and thus synchronous with it)
+set mainClk_and_generated {mainClk clk_sys clk_peri clk_usb clk_aon}
+# I/O clocks
+# TODO...
+
+## Virtual clocks based on generated clocks.
+# Defined here (after generated clocks) to avoid code constant duplication
+create_clock -name vclk_peri -period [get_property period [get_clocks clk_peri]]
+
+### Clock Uncertainty and Jitter ###
+# Primary clock comes from ASE-25.000MHZ-L-C-T crystal oscillator.
+# Reference Peak to Peak Jitter is 28 ps (with a note to contact ABRACOM)
+# and maximum RMS Jitter is 5 ps.
+# Use the worst value for now.
+set_input_jitter mainClk 0.028
+
+### Input and output delay constraints prep ###
+#
+## Make handy clock period variables for use in I/O delay constraints
+set mainClk_ns [get_property period [get_clocks mainClk]]
+# set tck_ns     [get_property period [get_clocks tck]]
+# SPI hosts can run as fast as half the rate of clk_sys
+set sclk_ns [expr {2 * [get_property period [get_clocks clk_peri]]}]
+
+### Input and output delay constraints proper ###
+
+#
+# TODO...
+#
+
+### Clock Groups and Clock False Paths ###
+# JTAG tck is completely asynchronous to FPGA mainClk and derivatives
+# set_clock_groups -asynchronous -group tck -group $mainClk_and_generated
+
+#### Timing Exceptions Section ####
+
+### False Paths ###
+
+## prim_flop_2sync
+# Set false_path timing exceptions on 2-stage synchroniser inputs.
+# Target the inputs because the flops inside are clocked by the destination.
+#
+# Reliant on the hierarchical pin names of the synchronisers remaining
+# unchanged during synthesis due to use of DONT_TOUCH or KEEP_HIERARCHY.
+set sync_cells [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
+set sync_pins [get_pins -filter {REF_PIN_NAME =~ d_i*} -of $sync_cells]
+# Filter out any that do not have a real timing path (fail to find leaf cell).
+set sync_endpoints [filter [all_fanout -endpoints_only -flat $sync_pins] IS_LEAF]
+set_false_path -to $sync_endpoints
+
+## prim_fifo_async and prim_fifo_async_simple
+# Set false_path timing exceptions on asynchronous fifo outputs.
+# Target the outputs because the storage elements are clocked by the source
+# clock domain (but made safe to read from the destination clock domain
+# thanks to the gray-coded read/write pointers and surrounding logic).
+#
+# Reliant on the hierarchical pin names used here remaining unchanged during
+# synthesis by setting DONT_TOUCH or KEEP_HIERARCHY earlier in the flow.
+set async_fifo_cells [get_cells -hier -regexp -filter {ORIG_REF_NAME =~ {prim_fifo_async(_simple)?}}]
+set async_fifo_pins [get_pins -filter {REF_PIN_NAME =~ rdata_o*} -of $async_fifo_cells]
+set async_fifo_startpoints [all_fanin -startpoints_only -flat $async_fifo_pins]
+# Specify `-through` as well as `-from` to avoid including non-rdata_o paths,
+# such as paths from the read pointers that stay internal or exit via rvalid_o.
+set_false_path -from $async_fifo_startpoints -through $async_fifo_pins
+
+### Max Delay / Min Delay ###
+
+## Reset async-assert sync-deassert CDC - async path to synchroniser reset pins
+# Use max_delay rather than false_path to avoid big skew between clock domains.
+#
+# Reliant on the hierarchical pin names used here remaining unchanged during
+# synthesis by setting DONT_TOUCH or KEEP_HIERARCHY earlier in the flow.
+set rst_sync_cells [get_cells u_clk_rst_gen/* -filter {ORIG_REF_NAME == prim_flop_2sync}]
+set rst_sync_pins [get_pins -filter {REF_PIN_NAME =~ rst_ni} -of $rst_sync_cells]
+# Filter out any that do not have a real timing path (fail to find leaf cell).
+set rst_sync_endpoints [filter [all_fanout -endpoints_only -flat $rst_sync_pins] IS_LEAF]
+set_max_delay 20 -to $rst_sync_endpoints  ;# keep path reasonably short
+
+### Multicycle Paths ###
+
+### Case Analysis ###
+
+### Disable Timing ###

--- a/hw/top_chip/fpga/flow/vivado_hook_opt_design_pre.tcl
+++ b/hw/top_chip/fpga/flow/vivado_hook_opt_design_pre.tcl
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This hook is only run when included in the flow by "vivado_setup.tcl".
+
+# Over-constrain clock used by the core during early implementation stages
+# to avoid/reduce post-route timing violations. Clear before route_design.
+#
+# Over-constraining works by making the tool work a bit harder to optimise
+# tight timing paths early on in the implementation flow. This is most
+# useful when the tool is under-estimating the future routing delay on
+# these paths, as can often happen in congested designs. Over-constraining
+# can also help post-route optimisation by improving timing in the wider
+# design, giving the optimiser less to fix and more paths that can tolerate
+# being adversely modified in order to improve the critical path. Note that
+# over-constraining too much can lead to increased runtime and worse timing
+# due to over-loading the tool.
+set_clock_uncertainty -setup 0.8 [get_clocks clk_sys]

--- a/hw/top_chip/fpga/flow/vivado_hook_route_design_pre.tcl
+++ b/hw/top_chip/fpga/flow/vivado_hook_route_design_pre.tcl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This hook is only run when included in the flow by "vivado_setup.tcl".
+
+# Clear clock over-constraint for the routing stage
+set_clock_uncertainty -setup 0 [get_clocks clk_sys]

--- a/hw/top_chip/fpga/flow/vivado_setup.tcl
+++ b/hw/top_chip/fpga/flow/vivado_setup.tcl
@@ -1,0 +1,84 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+## Vivado project custom configuration script
+##
+## For configuration not supported by fusesoc/edalize
+
+# Configure when and how the post-synthesis timing XDC file is read.
+# The `Tcl` `file_type` makes Vivado use the `-unmanaged` argument with
+# `read_xdc`, which allows us to use commands such as `foreach`.
+# The `used_in_synthesis` property makes Vivado delay reading the file
+# until after synthesis, allowing internal paths to be specified.
+# Note: `file_type` must be set before `used_in_synthesis`.
+set_property file_type Tcl [get_files impl_timing.xdc]
+set_property used_in_synthesis false [get_files impl_timing.xdc]
+
+# Set optimisation level for use in this hook and others later on.
+# - Set `opt` to `0` for no extra optimisation (Vivado default).
+# - Set `opt` to `1` for light & effective extra optimisation (general use).
+# - Set `opt` to `2` for heavy & chancy extra optimisation (short-term boost).
+set opt 1
+
+# Setup hook scripts, to be called at various stages during the build process
+# See Xilinx UG 894 ("Using Tcl Scripting") for documentation.
+#
+# fusesoc-generated workroot containing the Vivado project file
+set workroot [pwd]
+# Register custom hooks - must also be added to .core file
+# set_property STEPS.SYNTH_DESIGN.TCL.PRE     "${workroot}/vivado_hook_synth_design_pre.tcl"     [get_runs synth_1]
+# set_property STEPS.SYNTH_DESIGN.TCL.POST    "${workroot}/vivado_hook_synth_design_post.tcl"    [get_runs synth_1]
+if {$opt >= 1} {
+  # Set extra clock margin for early implementation stages
+  # (cleared in STEPS.ROUTE_DESIGN.TCL.PRE).
+  set_property STEPS.OPT_DESIGN.TCL.PRE       "${workroot}/vivado_hook_opt_design_pre.tcl"       [get_runs impl_1]
+}
+# set_property STEPS.OPT_DESIGN.TCL.POST      "${workroot}/vivado_hook_opt_design_post.tcl"      [get_runs impl_1]
+# set_property STEPS.PLACE_DESIGN.TCL.PRE     "${workroot}/vivado_hook_place_design_pre.tcl"     [get_runs impl_1]
+# set_property STEPS.PLACE_DESIGN.TCL.POST    "${workroot}/vivado_hook_place_design_post.tcl"    [get_runs impl_1]
+# set_property STEPS.PHYS_OPT_DESIGN.TCL.PRE  "${workroot}/vivado_hook_phys_opt_design_pre.tcl"  [get_runs impl_1]
+# set_property STEPS.PHYS_OPT_DESIGN.TCL.POST "${workroot}/vivado_hook_phys_opt_design_post.tcl" [get_runs impl_1]
+if {$opt >= 1} {
+  # Clear extra clock margin following early implementation stages
+  # (set in STEPS.OPT_DESIGN.TCL.PRE).
+  set_property STEPS.ROUTE_DESIGN.TCL.PRE     "${workroot}/vivado_hook_route_design_pre.tcl"     [get_runs impl_1]
+}
+# set_property STEPS.ROUTE_DESIGN.TCL.POST    "${workroot}/vivado_hook_route_design_post.tcl"    [get_runs impl_1]
+# set_property STEPS.WRITE_BITSTREAM.TCL.PRE  "${workroot}/vivado_hook_write_bitstream_pre.tcl"  [get_runs impl_1]
+# set_property STEPS.WRITE_BITSTREAM.TCL.POST "${workroot}/vivado_hook_write_bitstream_post.tcl" [get_runs impl_1]
+
+# Enable or tweak existing Vivado optimisation stages
+if {$opt >= 2} {
+  # Perform further logic optimisation to improve the timing fixing ability
+  # of post-route phys_opt_design optimisation. May make timing worse
+  # before post-route optimisation hopefully makes it better.
+  set opt_design_args {; opt_design -directive ExploreWithRemap}
+  set_property -name {STEPS.OPT_DESIGN.ARGS.MORE OPTIONS} -value $opt_design_args -object [get_runs impl_1]
+}
+if {$opt >= 1} {
+  set_property STEPS.POST_ROUTE_PHYS_OPT_DESIGN.IS_ENABLED TRUE [get_runs impl_1]
+  # Post-route optimisation that can fix small (~0.6 ns) timing failures
+  # at the cost of up to a few minutes additional runtime.
+  #
+  # From UG904: RuntimeOptimized
+  #   Provides a reduced set of physical optimizations with the shortest
+  #   runtime. Use this directive when compile time reduction is more important
+  #   than design performance. RuntimeOptimized includes fanout_opt,
+  #   critical_cell_opt, placement_opt, and bram_enable_opt.
+  set post_route_args {-directive RuntimeOptimized}
+  if {$opt >= 2} {
+    # Additional post-route optimisation that can help fix any remaining
+    # timing failures at the cost of up to several minutes additional runtime.
+    #
+    # From UG904: AggressiveExplore
+    #   Similar to Explore but with different optimization algorithms and
+    #   more aggressive goals. Includes a SLR crossing optimization phase that
+    #   is allowed to degrade WNS which should be regained in subsequent
+    #   optimization algorithms. Also includes a hold violation fixing
+    #   optimization.
+    # Appears to use different algorithm/optimisations from RuntimeOptimized.
+    set post_route_args [concat $post_route_args {; phys_opt_design -directive AggressiveExplore}]
+  }
+  set_property -name {STEPS.POST_ROUTE_PHYS_OPT_DESIGN.ARGS.MORE OPTIONS} -value $post_route_args -object [get_runs impl_1]
+}

--- a/hw/top_chip/fpga/rtl/clk_rst_gen_sonata_xl.sv
+++ b/hw/top_chip/fpga/rtl/clk_rst_gen_sonata_xl.sv
@@ -1,0 +1,216 @@
+// Copyright lowRISC contributors (Sunburst project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module clk_rst_gen_sonata_xl  #(
+  // Frequency of the board clock fed into the FPGA.
+  parameter int unsigned IOClkFreq = 25_000_000
+) (
+    // Board reset button
+    input  rst_btn_ni,
+
+    // Board clock signal
+    input  clk_board_i,
+
+    output clk_sys_o,
+    output clk_peri_o,
+    output clk_usb_o,
+    output clk_aon_o,
+
+    output rst_sys_no,
+    output rst_peri_no,
+    output rst_usb_no,
+    output rst_aon_no
+
+);
+  logic clk_board_buf;
+  logic clk_fb_buf;
+  logic clk_fb_unbuf;
+  logic clk_sys_buf;
+  logic clk_sys_unbuf;
+  logic clk_peri_buf;
+  logic clk_peri_unbuf;
+  logic clk_usb_buf;
+  logic clk_usb_unbuf;
+  logic clk_aon_buf;
+  logic clk_aon_unbuf;
+
+  // Indication that the PLL has stabilized and locked
+  logic pll_locked;
+
+  // Reset button signals
+  logic rst_btn_buf_n; // buffered
+  logic rst_btn_sync_n; // synchronised
+  logic rst_btn; // inverted (active-high)
+
+  // Board-clock-synchronous chip reset signal.
+  // Combines POR and debounced reset button.
+  logic rst_board_n;
+
+  // Input buffers
+  IBUF rst_board_ibuf(
+    .I (rst_btn_ni),
+    .O (rst_btn_buf_n)
+  );
+
+  IBUF clk_board_ibuf(
+    .I (clk_board_i),
+    .O (clk_board_buf)
+  );
+
+  // Clock synthesis
+  MMCME2_BASE #(
+    .BANDWIDTH            ("OPTIMIZED"),
+    .STARTUP_WAIT         ("FALSE"),
+    // Board clock
+    .CLKIN1_PERIOD        (1_000_000_000.0 / IOClkFreq), // nanoseconds
+    .DIVCLK_DIVIDE        (1),
+    // Feedback clock
+    .CLKFBOUT_MULT_F      (48),
+    .CLKFBOUT_PHASE       (0.000),
+    // clk_sys output - will differ from simulations due to FPGA limitations.
+    // CLKOUT0 is unique in supporting fractional divisors at 0.125 resolution.
+    .CLKOUT0_DIVIDE_F     ((48.0 * IOClkFreq) / top_chip_sonata_xl_pkg::SysClkFreq),
+    .CLKOUT0_PHASE        (0.000),
+    .CLKOUT0_DUTY_CYCLE   (0.500),
+    // clk_peri output
+    .CLKOUT1_DIVIDE       ((48 * IOClkFreq) / top_chip_system_pkg::PeriClkFreq),
+    .CLKOUT1_PHASE        (0.000),
+    .CLKOUT1_DUTY_CYCLE   (0.500),
+    // clk_usb output
+    .CLKOUT2_DIVIDE       ((48 * IOClkFreq) / top_chip_system_pkg::UsbClkFreq),
+    .CLKOUT2_PHASE        (0.000),
+    .CLKOUT2_DUTY_CYCLE   (0.500),
+    // Cascade CLKOUT6 output to CLKOUT4 input internally for a greater
+    // total divisor in order to reach AonClkFreq. See UG472 for details.
+    .CLKOUT4_CASCADE      ("TRUE"),
+    // AON First stage - intervening frequency
+    // Choose a frequency with a period that is a multiple of the desired
+    // AON clock period and that can be generated from the VCO frequency
+    // using a divisor within the supported range.
+    .CLKOUT6_DIVIDE       ((48 * IOClkFreq) / 20_000_000),
+    .CLKOUT6_PHASE        (0.000),
+    .CLKOUT6_DUTY_CYCLE   (0.500),
+    // AON Second stage - final clk_aon output
+    .CLKOUT4_DIVIDE       (20_000_000 / top_chip_system_pkg::AonClkFreq),
+    .CLKOUT4_PHASE        (0.000),
+    .CLKOUT4_DUTY_CYCLE   (0.500)
+  ) pll (
+    .CLKFBOUT            (clk_fb_unbuf),
+    .CLKFBOUTB           (),
+    .CLKOUT0             (clk_sys_unbuf),
+    .CLKOUT0B            (),
+    .CLKOUT1             (clk_peri_unbuf),
+    .CLKOUT1B            (),
+    .CLKOUT2             (clk_usb_unbuf),
+    .CLKOUT2B            (),
+    .CLKOUT3             (),
+    .CLKOUT3B            (),
+    .CLKOUT4             (clk_aon_unbuf),
+    .CLKOUT5             (),
+    .CLKOUT6             (/* used for clk_aon intermediate frequency */),
+    // Input clock control
+    .CLKFBIN             (clk_fb_buf),
+    .CLKIN1              (clk_board_buf),
+    // Control and status signals
+    .LOCKED              (pll_locked),
+    .PWRDWN              (1'b0),
+    // Do not reset PLL on external reset, otherwise ILA disconnects at a reset
+    .RST                 (1'b0)
+  );
+
+  // Output buffering
+  BUFG clk_fb_bufg (
+    .I (clk_fb_unbuf),
+    .O (clk_fb_buf)
+  );
+
+  BUFG clk_sys_bufg (
+    .I (clk_sys_unbuf),
+    .O (clk_sys_buf)
+  );
+
+  BUFG clk_peri_bufg (
+    .I (clk_peri_unbuf),
+    .O (clk_peri_buf)
+  );
+
+  BUFG clk_usb_bufg (
+    .I (clk_usb_unbuf),
+    .O (clk_usb_buf)
+  );
+
+  BUFG clk_aon_bufg (
+    .I (clk_aon_unbuf),
+    .O (clk_aon_buf)
+  );
+
+  // Clock outputs
+  assign clk_sys_o    = clk_sys_buf;
+  assign clk_peri_o   = clk_peri_buf;
+  assign clk_usb_o    = clk_usb_buf;
+  assign clk_aon_o    = clk_aon_buf;
+
+  // Reset button synchronisation and inversion
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_rst_btn_sync (
+    .clk_i(clk_board_buf),
+    .rst_ni(1'b1),
+    .d_i(rst_btn_buf_n),
+    .q_o(rst_btn_sync_n)
+  );
+  assign rst_btn = ~rst_btn_sync_n;
+
+  // Reset generation from power-on and on-board reset button
+  rst_ctrl u_rst_ctrl (
+    .clk_i       (clk_board_buf),
+    .pll_locked_i(pll_locked),
+    .rst_btn_i   (rst_btn),
+    .rst_no      (rst_board_n)
+  );
+
+  // De-assert synchronised resets (asynchronous assertion)
+  //
+  // clk_sys
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_rst_sys_sync (
+    .clk_i(clk_sys_buf),
+    .rst_ni(rst_board_n),
+    .d_i(1'b1),
+    .q_o(rst_sys_no)
+  );
+  // clk_peri
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_rst_peri_sync (
+    .clk_i(clk_peri_buf),
+    .rst_ni(rst_board_n),
+    .d_i(1'b1),
+    .q_o(rst_peri_no)
+  );
+  // clk_usb
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_rst_usb_sync (
+    .clk_i(clk_usb_buf),
+    .rst_ni(rst_board_n),
+    .d_i(1'b1),
+    .q_o(rst_usb_no)
+  );
+  // clk_aon
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_rst_aon_sync (
+    .clk_i(clk_aon_buf),
+    .rst_ni(rst_board_n),
+    .d_i(1'b1),
+    .q_o(rst_aon_no)
+  );
+
+endmodule

--- a/hw/top_chip/fpga/rtl/top_chip_sonata_xl.sv
+++ b/hw/top_chip/fpga/rtl/top_chip_sonata_xl.sv
@@ -1,0 +1,768 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sonata system top level for the Sonata PCB
+module top_chip_sonata_xl
+  import top_chip_sonata_xl_pkg::*;
+(
+  input  logic mainClk, // board clock
+  input  logic nrst, // on-board reset button
+
+  // LEDs
+  output logic usrLed0,
+  output logic usrLed1,
+  output logic usrLed2,
+  output logic usrLed3,
+  output logic usrLed4,
+  output logic usrLed5,
+  output logic usrLed6,
+  output logic usrLed7,
+  output logic led_bootok,
+  output logic led_halted,
+  output logic led_cheri,
+  output logic led_legacy,
+  output logic cheriErr0,
+  output logic cheriErr1,
+  output logic cheriErr2,
+  output logic cheriErr3,
+  output logic cheriErr4,
+  output logic cheriErr5,
+  output logic cheriErr6,
+  output logic cheriErr7,
+  output logic cheriErr8,
+
+  // Joystick
+  input  logic navSw_0,
+  input  logic navSw_1,
+  input  logic navSw_2,
+  input  logic navSw_3,
+  input  logic navSw_4,
+  // DIP switches
+  input  logic usrSw0,
+  input  logic usrSw1,
+  input  logic usrSw2,
+  input  logic usrSw3,
+  input  logic usrSw4,
+  input  logic usrSw5,
+  input  logic usrSw6,
+  input  logic usrSw7,
+  // SW App selector switch
+  input  logic selSw0,
+  input  logic selSw1,
+  input  logic selSw2,
+
+  output logic lcd_rst,
+  output logic lcd_dc,
+  output logic lcd_copi,
+  output logic lcd_clk,
+  output logic lcd_cs,
+  output logic lcd_backlight,
+
+  output logic ethmac_rst,
+  output logic ethmac_copi,
+  output logic ethmac_sclk,
+  input  logic ethmac_cipo,
+  input  logic ethmac_intr,
+  output logic ethmac_cs,
+
+  output logic rgbled0,
+  output logic rgbled_en,
+
+  // UART 0
+  output logic ser0_tx,
+  input  logic ser0_rx,
+
+  // UART 1
+  output logic ser1_tx,
+  input  logic ser1_rx,
+
+  // RS-232
+  output logic rs232_tx,
+  input  logic rs232_rx,
+
+  // RS-485
+  input  logic rs485_ro,
+  output logic rs485_de,
+  output logic rs485_ren,
+  output logic rs485_di,
+
+  // QWIIC (Sparkfun) buses
+  inout  logic scl0,  // qwiic0 and Arduino Header
+  inout  logic sda0,
+
+  inout  logic scl1,  // qwiic1
+  inout  logic sda1,
+
+  // R-Pi header I2C buses
+  inout  logic rph_g3_scl,  // SCL1/GPIO3 on Header
+  inout  logic rph_g2_sda,  // SDA1/GPIO2
+
+  inout  logic rph_g1,  // ID_SC for HAT ID EEPROM
+  inout  logic rph_g0,  // ID_SD
+
+  // R-Pi header SPI buses
+  inout  logic rph_g11_sclk, // SPI0
+  inout  logic rph_g10_copi, // SPI0
+  inout  logic rph_g9_cipo,  // SPI0
+  inout  logic rph_g8_ce0,   // SPI0
+  inout  logic rph_g7_ce1,   // SPI0
+
+  inout  logic rph_g21_sclk, // SPI1
+  inout  logic rph_g20_copi, // SPI1
+  inout  logic rph_g19_cipo, // SPI1
+  inout  logic rph_g18,      // SPI1 CE0
+  inout  logic rph_g17,      // SPI1 CE1
+  inout  logic rph_g16_ce2,  // SPI1
+
+  // R-Pi header UART
+  inout  logic rph_txd0,
+  inout  logic rph_rxd0,
+
+  // R-Pi header GPIO
+  inout  logic rph_g27,
+  inout  logic rph_g26,
+  inout  logic rph_g25,
+  inout  logic rph_g24,
+  inout  logic rph_g23,
+  inout  logic rph_g22,
+  inout  logic rph_g13,
+  inout  logic rph_g12,
+  inout  logic rph_g6,
+  inout  logic rph_g5,
+  inout  logic rph_g4,
+
+  // Arduino shield GPIO
+  inout  logic ah_tmpio0,
+  inout  logic ah_tmpio1,
+  inout  logic ah_tmpio2,
+  inout  logic ah_tmpio3,
+  inout  logic ah_tmpio4,
+  inout  logic ah_tmpio5,
+  inout  logic ah_tmpio6,
+  inout  logic ah_tmpio7,
+  inout  logic ah_tmpio8,
+  inout  logic ah_tmpio9,
+
+  // Arduino shield SPI bus
+  inout  logic ah_tmpio10, // Chip select
+  inout  logic ah_tmpio11, // COPI
+  inout  logic ah_tmpio12, // CIPO or GP
+  inout  logic ah_tmpio13, // SCLK
+
+  // Arduino/AVR In-Circuit Serial Programming (ICSP) header
+  // (useful for outputting debug signals)
+  output logic      ah_tmpio14, // CIPO
+  output logic      ah_tmpio15, // SCK
+  output logic      ah_tmpio16, // COPI
+  output logic      ah_tmpio17, // IO (a.k.a. RST)
+
+  // Arduino shield analog(ue) pins digital inputs
+  input logic analog0_digital,
+  input logic analog1_digital,
+  input logic analog2_digital,
+  input logic analog3_digital,
+  input logic analog4_digital,
+  input logic analog5_digital,
+
+  // Arduino shield analog(ue) pins actual analog(ue) input pairs
+  input wire  analog0_p,
+  input wire  analog0_n,
+  input wire  analog1_p,
+  input wire  analog1_n,
+  input wire  analog2_p,
+  input wire  analog2_n,
+  input wire  analog3_p,
+  input wire  analog3_n,
+  input wire  analog4_p,
+  input wire  analog4_n,
+  input wire  analog5_p,
+  input wire  analog5_n,
+
+  // mikroBUS Click other
+  output logic mb10, // PWM
+  input  logic mb9,  // Interrupt
+  output logic mb0,  // Reset
+
+  // mikroBUS Click UART
+  input  logic mb8,  // RX
+  output logic mb7,  // TX
+
+  // mikroBUS Click I2C bus
+  inout  logic mb6,  // SCL
+  inout  logic mb5,  // SDA
+
+  // mikroBUS Click SPI
+  output logic mb4,  // COPI
+  input  logic mb3,  // CIPO
+  output logic mb2,  // SCK
+  output logic mb1,  // Chip select
+
+  // PMOD0
+  inout  logic pmod0_1,
+  inout  logic pmod0_2,
+  inout  logic pmod0_3,
+  inout  logic pmod0_4,
+  inout  logic pmod0_5,
+  inout  logic pmod0_6,
+  inout  logic pmod0_7,
+  inout  logic pmod0_8,
+  // PMODC (the pins between PMOD0 and PMOD1)
+  inout  logic pmodc_1,
+  inout  logic pmodc_2,
+  inout  logic pmodc_3,
+  inout  logic pmodc_4,
+  inout  logic pmodc_5,
+  inout  logic pmodc_6,
+  // PMOD1
+  inout  logic pmod1_1,
+  inout  logic pmod1_2,
+  inout  logic pmod1_3,
+  inout  logic pmod1_4,
+  inout  logic pmod1_5,
+  inout  logic pmod1_6,
+  inout  logic pmod1_7,
+  inout  logic pmod1_8,
+
+  // Status input from USB transceiver
+  input  logic usrusb_vbusdetect,
+
+  // Control of USB transceiver
+  output logic usrusb_softcn,
+  // Configure the USB transceiver for Full Speed operation.
+  output logic usrusb_spd,
+
+  // Reception from USB host via transceiver
+  input  logic usrusb_v_p,
+  input  logic usrusb_v_n,
+  input  logic usrusb_rcv,
+
+  // Transmission to USB host via transceiver
+  output logic usrusb_vpo,
+  output logic usrusb_vmo,
+
+  // Always driven configuration signals to the USB transceiver.
+  output logic usrusb_oe,
+  output logic usrusb_sus,
+
+  // User JTAG
+  input  logic tck_i,
+  input  logic tms_i,
+  input  logic td_i,
+  output logic td_o,
+
+  // SPI flash interface
+  output logic appspi_clk,
+  output logic appspi_d0, // COPI (controller output peripheral input)
+  input  logic appspi_d1, // CIPO (controller input peripheral output)
+  output logic appspi_d2, // WP_N (write protect negated)
+  output logic appspi_d3, // HOLD_N or RESET_N
+  output logic appspi_cs, // Chip select negated
+
+  // MicroSD card slot
+  output logic microsd_clk,  // SPI mode: SCLK
+  input  logic microsd_dat0, // SPI mode: CIPO
+//input  logic microsd_dat1, // SPI mode: NC
+//input  logic microsd_dat2, // SPI mode: NC
+  output logic microsd_dat3, // SPI mode: CS_N
+  output logic microsd_cmd,  // SPI mode: COPI
+  input  logic microsd_det,   // Card insertion detection
+
+  // XL expansion headers
+  inout  logic ex0_0,
+  inout  logic ex0_1,
+  inout  logic ex0_2,
+  inout  logic ex0_3,
+  inout  logic ex0_4,
+  inout  logic ex0_5,
+  inout  logic ex0_6,
+  inout  logic ex0_7,
+  inout  logic ex0_8,
+  inout  logic ex0_9,
+  inout  logic ex0_10,
+  inout  logic ex0_11,
+  inout  logic ex0_12,
+  inout  logic ex0_13,
+  inout  logic ex0_14,
+  inout  logic ex0_15,
+  inout  logic ex0_16,
+  inout  logic ex0_17,
+  inout  logic ex0_18,
+  inout  logic ex0_19,
+  inout  logic ex0_20,
+  inout  logic ex0_21,
+  inout  logic ex0_22,
+  inout  logic ex0_23,
+  inout  logic ex0_24,
+  inout  logic ex0_25,
+  inout  logic ex0_26,
+  inout  logic ex0_27,
+  inout  logic ex0_28,
+  inout  logic ex0_29,
+  inout  logic ex0_30,
+  inout  logic ex0_31,
+  inout  logic ex0_32,
+  inout  logic ex0_33,
+  inout  logic ex0_34,
+  inout  logic ex0_35,
+  inout  logic ex0_36,
+  inout  logic ex0_37,
+  inout  logic ex0_38,
+  inout  logic ex0_39,
+  inout  logic ex0_40,
+  inout  logic ex0_41,
+  inout  logic ex0_42,
+  inout  logic ex0_43,
+  inout  logic ex0_44,
+  inout  logic ex0_45,
+  inout  logic ex0_46,
+  inout  logic ex0_47,
+  inout  logic ex0_48,
+  inout  logic ex0_49,
+  inout  logic ex0_50,
+  inout  logic ex0_51,
+  inout  logic ex0_52,
+  inout  logic ex0_53,
+  inout  logic ex0_54,
+  inout  logic ex0_55,
+  inout  logic ex0_56,
+  inout  logic ex0_57,
+  inout  logic ex0_58,
+  inout  logic ex0_59,
+  inout  logic ex0_60,
+  inout  logic ex0_61,
+  inout  logic ex0_62,
+  inout  logic ex0_63,
+  inout  logic ex1_0,
+  inout  logic ex1_1,
+  inout  logic ex1_2,
+  inout  logic ex1_3,
+  inout  logic ex1_4,
+  inout  logic ex1_5,
+  inout  logic ex1_6,
+  inout  logic ex1_7,
+  inout  logic ex1_8,
+  inout  logic ex1_9,
+  inout  logic ex1_10,
+  inout  logic ex1_11,
+  inout  logic ex1_12,
+  inout  logic ex1_13,
+  inout  logic ex1_14,
+  inout  logic ex1_15,
+  inout  logic ex1_16,
+  inout  logic ex1_17,
+  inout  logic ex1_18,
+  inout  logic ex1_19,
+  inout  logic ex1_20,
+  inout  logic ex1_21,
+  inout  logic ex1_22,
+  inout  logic ex1_23,
+  inout  logic ex1_24,
+  inout  logic ex1_25,
+  inout  logic ex1_26,
+  inout  logic ex1_27,
+  inout  logic ex1_28,
+  inout  logic ex1_29,
+  inout  logic ex1_30,
+  inout  logic ex1_31,
+  inout  logic ex1_32,
+  inout  logic ex1_33,
+  inout  logic ex1_34,
+  inout  logic ex1_35,
+  inout  logic ex1_36,
+  inout  logic ex1_37,
+  inout  logic ex1_38,
+  inout  logic ex1_39,
+  inout  logic ex1_40,
+  inout  logic ex1_41,
+  inout  logic ex1_42,
+  inout  logic ex1_43,
+  inout  logic ex1_44,
+  inout  logic ex1_45,
+  inout  logic ex1_46,
+  inout  logic ex1_47,
+  inout  logic ex1_48,
+  inout  logic ex1_49,
+  inout  logic ex1_50,
+  inout  logic ex1_51,
+  inout  logic ex1_52,
+  inout  logic ex1_53,
+  inout  logic ex1_54,
+  inout  logic ex1_55,
+  inout  logic ex1_56,
+  inout  logic ex1_57,
+  inout  logic ex1_58,
+  inout  logic ex1_59,
+  inout  logic ex1_60,
+  inout  logic ex1_61,
+  inout  logic ex1_62,
+  inout  logic ex1_63
+);
+
+  // TODO: Remove SRAMInitFile when have an alt way to load programs into FPGA
+  parameter SRAMInitFile = "";
+
+  // System clock and reset
+  logic clk_sys;
+  logic rst_sys_n;
+
+  // Peripheral clock and reset
+  logic clk_peri;
+  logic rst_peri_n;
+
+  // USB device clock and reset
+  logic clk_usb;
+  logic rst_usb_n;
+
+  // Always-ON clock and reset
+  logic clk_aon;
+  logic rst_aon_n;
+
+  // Output enable signals for output-only ports not going via padring
+  logic pwm_raw, pwm_en;
+  logic pattgen_pda0_raw, pattgen_pda0_en;
+  logic pattgen_pcl0_raw, pattgen_pcl0_en;
+  logic pattgen_pda1_raw, pattgen_pda1_en;
+  logic pattgen_pcl1_raw, pattgen_pcl1_en;
+  logic spi0_sck_raw, spi0_sck_en;
+  logic spi0_csb_raw, spi0_csb_en;
+  logic [3:0] spi0_sdo_raw, spi0_sdo_en;
+  logic spi1_sck_raw, spi1_sck_en;
+  logic spi1_csb_raw, spi1_csb_en;
+  logic [3:0] spi1_sdo_raw, spi1_sdo_en;
+  logic uart0_tx_raw, uart0_tx_en;
+  logic uart1_tx_raw, uart1_tx_en;
+
+  logic _unused_out;
+
+  logic dp_en_d2p;
+  logic rx_enable_d2p;
+
+  sonata_xl_inout_pins_t inout_from_pins, inout_to_pins, inout_to_pins_en;
+
+  top_chip_system #(
+    .SRAMInitFile(SRAMInitFile)
+  ) u_top_chip_system (
+    .clk_sys_i  (clk_sys),
+    .clk_peri_i (clk_peri),
+    .clk_usb_i  (clk_usb),
+    .clk_aon_i  (clk_aon),
+
+    .rst_sys_ni   (rst_sys_n),
+    .rst_peri_ni  (rst_peri_n),
+    .rst_usb_ni   (rst_usb_n),
+    .rst_aon_ni   (rst_aon_n),
+
+    // GPIO over PMOD and RPi header
+    .cio_gpio_i     (inout_from_pins[INOUT_PIN_GPIO_END : INOUT_PIN_GPIO_START]),
+    .cio_gpio_o     (inout_to_pins[INOUT_PIN_GPIO_END : INOUT_PIN_GPIO_START]),
+    .cio_gpio_en_o  (inout_to_pins_en[INOUT_PIN_GPIO_END : INOUT_PIN_GPIO_START]),
+
+    // PMOD1
+    .cio_i2c0_sda_i     (inout_from_pins[INOUT_PIN_SDA0]),
+    .cio_i2c0_scl_i     (inout_from_pins[INOUT_PIN_SCL0]),
+    .cio_i2c0_sda_o     (inout_to_pins[INOUT_PIN_SDA0]),
+    .cio_i2c0_scl_o     (inout_to_pins[INOUT_PIN_SCL0]),
+    .cio_i2c0_sda_en_o  (inout_to_pins_en[INOUT_PIN_SDA0]),
+    .cio_i2c0_scl_en_o  (inout_to_pins_en[INOUT_PIN_SCL0]),
+
+    // QWIIC1 I^2C
+    .cio_i2c1_sda_i     (inout_from_pins[INOUT_PIN_SDA1]),
+    .cio_i2c1_scl_i     (inout_from_pins[INOUT_PIN_SCL1]),
+    .cio_i2c1_sda_o     (inout_to_pins[INOUT_PIN_SDA1]),
+    .cio_i2c1_scl_o     (inout_to_pins[INOUT_PIN_SCL1]),
+    .cio_i2c1_sda_en_o  (inout_to_pins_en[INOUT_PIN_SDA1]),
+    .cio_i2c1_scl_en_o  (inout_to_pins_en[INOUT_PIN_SCL1]),
+
+    // mikroBUS header PWM
+    .cio_pwm_o    (pwm_raw),
+    .cio_pwm_en_o (pwm_en),
+
+    // Pattgen output over Arduino D0-D3 pins
+    .cio_pattgen_pda0_tx_o(pattgen_pda0_raw),
+    .cio_pattgen_pcl0_tx_o(pattgen_pcl0_raw),
+    .cio_pattgen_pda1_tx_o(pattgen_pda1_raw),
+    .cio_pattgen_pcl1_tx_o(pattgen_pcl1_raw),
+    .cio_pattgen_pda0_tx_en_o(pattgen_pda0_en),
+    .cio_pattgen_pcl0_tx_en_o(pattgen_pcl0_en),
+    .cio_pattgen_pda1_tx_en_o(pattgen_pda1_en),
+    .cio_pattgen_pcl1_tx_en_o(pattgen_pcl1_en),
+
+    // PMOD0 SPI.
+    // Only using one data-bit per direction.
+    .cio_spi_host0_sd_i     ({3'b000, pmod0_3}),
+    .cio_spi_host0_sck_o    (spi0_sck_raw),
+    .cio_spi_host0_csb_o    (spi0_csb_raw),
+    .cio_spi_host0_sd_o     (spi0_sdo_raw),
+    .cio_spi_host0_sck_en_o (spi0_sck_en),
+    .cio_spi_host0_csb_en_o (spi0_csb_en),
+    .cio_spi_host0_sd_en_o  (spi0_sdo_en),
+
+    // mikroBUS header SPI.
+    // Only using one data-bit per direction.
+    .cio_spi_host1_sd_i     ({3'b000, mb3}),
+    .cio_spi_host1_sck_o    (spi1_sck_raw),
+    .cio_spi_host1_csb_o    (spi1_csb_raw),
+    .cio_spi_host1_sd_o     (spi1_sdo_raw),
+    .cio_spi_host1_sck_en_o (spi1_sck_en),
+    .cio_spi_host1_csb_en_o (spi1_csb_en),
+    .cio_spi_host1_sd_en_o  (spi1_sdo_en),
+
+    // ser0 for FTDI channel-C UART (via jumpers)
+    .cio_uart0_rx_i     (ser0_rx),
+    .cio_uart0_tx_o     (uart0_tx_raw),
+    .cio_uart0_tx_en_o  (uart0_tx_en),
+
+    // mikroBUS header TX/RX
+    .cio_uart1_rx_i     (mb8),
+    .cio_uart1_tx_o     (uart1_tx_raw),
+    .cio_uart1_tx_en_o  (uart1_tx_en),
+
+    // USB transceiver
+    .cio_usbdev_sense_i         (usrusb_vbusdetect),
+    .cio_usbdev_usb_dp_i        (usrusb_v_p),
+    .cio_usbdev_usb_dn_i        (usrusb_v_n),
+    .cio_usbdev_rx_d_i          (usrusb_rcv),
+    .cio_usbdev_usb_dp_o        (usrusb_vpo),
+    .cio_usbdev_usb_dp_en_o     (dp_en_d2p),
+    .cio_usbdev_usb_dn_o        (usrusb_vmo),
+    .cio_usbdev_usb_dn_en_o     (),
+    .cio_usbdev_tx_d_o          (),
+    .cio_usbdev_tx_se0_o        (),
+    .cio_usbdev_tx_use_d_se0_o  (),
+    .cio_usbdev_dp_pullup_o     (usrusb_softcn),
+    .cio_usbdev_dn_pullup_o     (),
+    .cio_usbdev_rx_enable_o     (rx_enable_d2p),
+
+    // TODO: Connect aon timer to sleep and reset managers (when present)
+    .aon_timer_wkup_req_o(),
+    .aon_timer_rst_req_o (),
+
+    .scanmode_i  (prim_mubi_pkg::MuBi4False),
+    .ram_1p_cfg_i('0),
+    .ram_2p_cfg_i('0),
+    .rom_cfg_i   ('0)
+  );
+
+  // Enable logic for output-only ports
+  assign mb10 = pwm_raw & pwm_en;    // PWM (external header copy)
+  assign usrLed0 = pwm_raw & pwm_en; // PWM (on-board LED copy)
+  assign ah_tmpio0 = pattgen_pda0_raw & pattgen_pda0_en; // pattgen ch0
+  assign ah_tmpio1 = pattgen_pcl0_raw & pattgen_pcl0_en; // pattgen ch0
+  assign ah_tmpio2 = pattgen_pda1_raw & pattgen_pda1_en; // pattgen ch1
+  assign ah_tmpio3 = pattgen_pcl1_raw & pattgen_pcl1_en; // pattgen ch1
+  assign pmod0_4 = spi0_sck_raw & spi0_sck_en; // SPI0
+  assign pmod0_1 = spi0_csb_raw & spi0_csb_en; // SPI0
+  assign pmod0_2 = spi0_sdo_raw[0] & spi0_sdo_en[0]; // SPI0
+  assign mb2 = spi1_sck_raw & spi1_sck_en; // SPI1
+  assign mb1 = spi1_csb_raw & spi1_csb_en; // SPI1
+  assign mb4 = spi1_sdo_raw[0] & spi1_sdo_en[0]; // SPI1
+  assign ser0_tx = uart0_tx_raw & uart0_tx_en; // UART0
+  assign mb7 = uart1_tx_raw & uart1_tx_en; // UART1
+
+  assign _unused_out = ^{spi0_sdo_raw[3:1],
+                         spi0_sdo_en[3:1],
+                         spi1_sdo_raw[3:1],
+                         spi1_sdo_en[3:1]};
+
+  assign usrusb_spd = 1'b1;  // Full Speed operation.
+
+  assign usrusb_oe  = !dp_en_d2p;  // Active low Output Enable.
+  assign usrusb_sus = !rx_enable_d2p;
+
+  // Tie flash wp_n and hold_n to 1 as they're active low and we don't need either signal
+  assign appspi_d2 = 1'b1;
+  assign appspi_d3 = 1'b1;
+
+  // Use core reset signal as a boot indicator
+  assign led_bootok = rst_sys_n;
+
+  // Always running with CHERI
+  assign led_cheri = 1'b1;
+  assign led_legacy = 1'b0;
+  assign led_halted = 1'b0;
+
+  // Keep error LEDs off, as we have no core integration to drive them
+  assign cheriErr0 = 1'b0;
+  assign cheriErr1 = 1'b0;
+  assign cheriErr2 = 1'b0;
+  assign cheriErr3 = 1'b0;
+  assign cheriErr4 = 1'b0;
+  assign cheriErr5 = 1'b0;
+  assign cheriErr6 = 1'b0;
+  assign cheriErr7 = 1'b0;
+  assign cheriErr8 = 1'b0;
+
+  // Keep RGB LEDs disabled while we have no hardware to talk to them
+  assign rgbled_en = 1'b0;
+
+  // mikroBUS Click boards mostly use this pin as an active low reset signal but some
+  // boards use it as an active low Read Enable (RE) pin; presently this pin is not
+  // under software control so some boards are not supported.
+  assign mb0 = 1'b1;
+
+  // Produce system clocks and matching de-assert synchronous resets
+  // from 25 MHz Sonata XL board clock.
+  clk_rst_gen_sonata_xl u_clk_rst_gen(
+    .rst_btn_ni   (nrst),
+    .clk_board_i  (mainClk),
+    .clk_sys_o    (clk_sys),
+    .clk_peri_o   (clk_peri),
+    .clk_usb_o    (clk_usb),
+    .clk_aon_o    (clk_aon),
+    .rst_sys_no   (rst_sys_n),
+    .rst_peri_no  (rst_peri_n),
+    .rst_usb_no   (rst_usb_n),
+    .rst_aon_no   (rst_aon_n)
+  );
+
+  // Inout Pins
+  padring #(
+    .InoutNumber(INOUT_PIN_NUM)
+  ) u_padring (
+    .inout_to_pins_i   (inout_to_pins   ),
+    .inout_to_pins_en_i(inout_to_pins_en),
+    .inout_from_pins_o (inout_from_pins ),
+    .inout_pins_io({
+      // Notice: Please update INOUT_PIN_* definitions in top_chip_sonata_xl_pkg
+      //         to match any changes of purpose to the list of ports below.
+      pmod1_3, // INOUT_PIN_SCL0
+      pmod1_4, // INOUT_PIN_SDA0
+      scl1, // INOUT_PIN_SCL1
+      sda1, // INOUT_PIN_SDA1
+      // INOUT_PIN_GPIO_START
+      rph_g0, // GPIO 0
+      rph_g1,
+      rph_g2_sda,
+      rph_g3_scl,
+      rph_g4,
+      rph_g5,
+      rph_g6,
+      rph_g7_ce1,
+      rph_g8_ce0,
+      rph_g9_cipo,
+      rph_g10_copi,
+      rph_g11_sclk,
+      rph_g12,
+      rph_g13,
+      rph_txd0, // g14
+      rph_rxd0, // g15
+      rph_g16_ce2,
+      rph_g17,
+      rph_g18,
+      rph_g19_cipo,
+      rph_g20_copi,
+      rph_g21_sclk,
+      rph_g22,
+      rph_g23,
+      rph_g24,
+      rph_g25,
+      rph_g26,
+      rph_g27, // GPIO 27
+      pmod0_5, // GPIO 28
+      pmod0_6, // GPIO 29
+      pmod0_7, // GPIO 30
+      pmod0_8  // GPIO 31
+      // INOUT_PIN_GPIO_END
+    })
+  );
+
+  // Debug signals for viewing on external logic analyser via P11 header.
+  logic [3:0] dbg;
+  always_comb begin : dbg_case
+    case ({usrSw3, usrSw2, usrSw1, usrSw0})
+      4'b0000: begin
+        dbg[0] = u_clk_rst_gen.clk_board_buf;
+        dbg[1] = u_clk_rst_gen.pll_locked;
+        dbg[2] = u_clk_rst_gen.rst_btn_buf_n;
+        dbg[3] = u_clk_rst_gen.rst_btn_sync_n;
+      end
+      4'b0001: begin
+        dbg[0] = u_clk_rst_gen.pll_locked;
+        dbg[1] = u_clk_rst_gen.rst_btn;
+        dbg[2] = u_clk_rst_gen.rst_board_n;
+        dbg[3] = u_clk_rst_gen.rst_sys_no;
+      end
+      4'b0010: begin
+        dbg[0] = clk_sys;
+        dbg[1] = clk_peri;
+        dbg[2] = clk_usb;
+        dbg[3] = clk_aon;
+      end
+      4'b0011: begin
+        dbg[0] = rst_sys_n;
+        dbg[1] = rst_peri_n;
+        dbg[2] = rst_usb_n;
+        dbg[3] = rst_aon_n;
+      end
+      4'b0100: begin
+        dbg[0] = clk_sys;
+        dbg[1] = rst_sys_n;
+        dbg[2] = u_top_chip_system.u_core_ibex.core_instr_req;
+        dbg[3] = u_top_chip_system.u_core_ibex.core_instr_gnt;
+      end
+      4'b0101: begin
+        dbg[0] = clk_sys;
+        dbg[1] = rst_sys_n;
+        dbg[2] = u_top_chip_system.u_core_ibex.core_instr_rvalid;
+        dbg[3] = u_top_chip_system.u_core_ibex.core_instr_err;
+      end
+      4'b1000: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[0];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[1];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[2];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[3];
+      end
+      4'b1001: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[4];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[5];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[6];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[7];
+      end
+      4'b1010: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[8];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[9];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[10];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[11];
+      end
+      4'b1011: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[12];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[13];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[14];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[15];
+      end
+      4'b1100: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[16];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[17];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[18];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[19];
+      end
+      4'b1101: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[20];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[21];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[22];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[23];
+      end
+      4'b1110: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[24];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[25];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[26];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[27];
+      end
+      4'b1111: begin
+        dbg[0] = u_top_chip_system.u_sram.u_ram.rdata_o[28];
+        dbg[1] = u_top_chip_system.u_sram.u_ram.rdata_o[29];
+        dbg[2] = u_top_chip_system.u_sram.u_ram.rdata_o[30];
+        dbg[3] = u_top_chip_system.u_sram.u_ram.rdata_o[31];
+      end
+      default:
+        dbg = 'd1111;
+    endcase
+  end
+  // Explicitly instantiate output buffers to avoid the signals being renamed.
+  OBUF u_ah_tmpio14_buf ( .O(ah_tmpio14), .I(dbg[0]) );
+  OBUF u_ah_tmpio15_buf ( .O(ah_tmpio15), .I(dbg[1]) );
+  OBUF u_ah_tmpio16_buf ( .O(ah_tmpio16), .I(dbg[2]) );
+  OBUF u_ah_tmpio17_buf ( .O(ah_tmpio17), .I(dbg[3]) );
+
+endmodule : top_chip_sonata_xl

--- a/hw/top_chip/fpga/rtl/top_chip_sonata_xl_pkg.sv
+++ b/hw/top_chip/fpga/rtl/top_chip_sonata_xl_pkg.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (Sunburst project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sonata XL package
+
+package top_chip_sonata_xl_pkg;
+
+// System clock frequency for Sonata XL.
+// Set to the fastest we can reliably synthesise on the A200T FPGA.
+parameter int unsigned SysClkFreq = 40_000_000;
+
+// Number of Instances
+localparam int unsigned GPIO_NUM = 1;
+localparam int unsigned PWM_NUM = 1;
+localparam int unsigned UART_NUM = 2;
+localparam int unsigned I2C_NUM = 2;
+localparam int unsigned SPI_NUM = 2;
+
+// Width of block IO arrays
+localparam int unsigned GPIO_IOS_WIDTH = 32;
+localparam int unsigned PWM_OUT_WIDTH = 1;
+localparam int unsigned SPI_CS_WIDTH = 1;
+
+// inout pins
+localparam int unsigned INOUT_PIN_SCL0        = 0;
+localparam int unsigned INOUT_PIN_SDA0        = 1;
+localparam int unsigned INOUT_PIN_SCL1        = 2;
+localparam int unsigned INOUT_PIN_SDA1        = 3;
+localparam int unsigned INOUT_PIN_GPIO_START  = 4;
+localparam int unsigned INOUT_PIN_GPIO_END    = 4 + (GPIO_IOS_WIDTH - 1);
+localparam int unsigned INOUT_PIN_NUM         = INOUT_PIN_GPIO_END + 1; // number of inout pins
+
+typedef logic [INOUT_PIN_NUM-1:0] sonata_xl_inout_pins_t;
+
+endpackage : top_chip_sonata_xl_pkg

--- a/hw/top_chip/fpga/top_chip_sonata_xl.core
+++ b/hw/top_chip/fpga/top_chip_sonata_xl.core
@@ -1,0 +1,75 @@
+CAPI=2:
+# Copyright lowRISC contributors (Sunburst project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:sunburst:top_chip_sonata_xl"
+description: "Sonata XL FPGA implementation of Sunburst chip"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:mubi
+      - lowrisc:sunburst:top_chip_system
+
+  files_sonata_xl:
+    depend:
+      - lowrisc:ibex:fpga_xilinx_shared
+      - lowrisc:sunburst:top_chip_system_pkg
+      - lowrisc:sunburst:sonata_fpga
+    files:
+      - rtl/top_chip_sonata_xl_pkg.sv
+      - rtl/top_chip_sonata_xl.sv
+      - rtl/clk_rst_gen_sonata_xl.sv
+    file_type: systemVerilogSource
+
+  files_constraints_sonata:
+    files:
+      # Per AMD advice (UG949):
+      - data/pins_sonata_xl.xdc  # 1 file for physical +
+      - data/synth_timing.xdc # 1 file for timing (synthesis) +
+      - data/impl_timing.xdc  # 1 file for timing (implementation)
+    file_type: xdc
+
+  files_tcl:
+    files:
+      - flow/vivado_setup.tcl : { file_type: tclSource }
+      - flow/vivado_hook_opt_design_pre.tcl : { file_type: user, copyto: vivado_hook_opt_design_pre.tcl }
+      - flow/vivado_hook_route_design_pre.tcl : { file_type: user, copyto: vivado_hook_route_design_pre.tcl }
+
+parameters:
+  # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
+  # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
+  # --SRAMInitFile=$PWD/scratch_sw/bare_metal/build/checks/chip_check.vmem
+  # XXX: The VMEM file should be added to the sources of the Vivado project to
+  # make the Vivado dependency tracking work. However this requires changes to
+  # fusesoc first.
+  SRAMInitFile:
+    datatype: str
+    description: SRAM initialization file in vmem hex format
+    default: "../../../../../scratch_sw/bare_metal/build/checks/chip_check.vmem"
+    paramtype: vlogparam
+
+  # For value definition, please see ip/prim/rtl/prim_pkg.sv
+  PRIM_DEFAULT_IMPL:
+    datatype: str
+    paramtype: vlogdefine
+    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl
+
+  synth:
+    <<: *default_target
+    default_tool: vivado
+    filesets_append:
+      - files_sonata_xl
+      - files_constraints_sonata
+      - files_tcl
+    toplevel: top_chip_sonata_xl
+    tools:
+      vivado:
+        part: "xc7a200tfbg676-2" # Sonata XL v0.2
+    parameters:
+      - SRAMInitFile
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx

--- a/hw/vendor/lowrisc_sonata.vendor.hjson
+++ b/hw/vendor/lowrisc_sonata.vendor.hjson
@@ -12,5 +12,9 @@
 
     mapping: [
         {from: "rtl/ip/rev_ctl", to: "rtl/ip/rev_ctl"},
+
+        {from: "rtl/system/debounce.sv", to: "rtl/fpga/debounce.sv"},
+        {from: "rtl/fpga/padring.sv", to: "rtl/fpga/padring.sv"},
+        {from: "rtl/fpga/rst_ctrl.sv", to: "rtl/fpga/rst_ctrl.sv"},
     ],
 }

--- a/hw/vendor/lowrisc_sonata/rtl/fpga/debounce.sv
+++ b/hw/vendor/lowrisc_sonata/rtl/fpga/debounce.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Maintain a counter that increments whilst the input is in the opposite state
+// from the debounced output. If the input remains in that state for a certain
+// number of cycles (ClkCount) it is deemed stable and becomes the debounced
+// output. If the input changes (i.e. it is bouncing) we reset the counter.
+
+typedef int unsigned count_t;
+
+module debounce #(
+    parameter count_t ClkCount = 500
+) (
+    input  logic clk_i,
+    input  logic rst_ni,
+
+    input  logic btn_i,
+    output logic btn_o
+);
+
+  logic [$clog2(ClkCount+1)-1:0] cnt_d, cnt_q;
+  logic btn_d, btn_q;
+
+  assign btn_o = btn_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_fsm_reg
+    if (!rst_ni) begin
+      cnt_q <= '0;
+      btn_q <= '0;
+    end else begin
+      cnt_q <= cnt_d;
+      btn_q <= btn_d;
+    end
+  end
+
+  assign btn_d = (count_t'(cnt_q) >= ClkCount) ? btn_i : btn_q;
+  // Clear counter if button input equals stored value or if maximum counter value is reached,
+  // otherwise increment counter.
+  assign cnt_d = (btn_i == btn_q || count_t'(cnt_q) >= ClkCount) ? '0 : cnt_q + 1;
+
+endmodule

--- a/hw/vendor/lowrisc_sonata/rtl/fpga/padring.sv
+++ b/hw/vendor/lowrisc_sonata/rtl/fpga/padring.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module padring #(
+  parameter int unsigned InoutNumber = 1
+) (
+  input  logic [InoutNumber-1:0] inout_to_pins_i,
+  input  logic [InoutNumber-1:0] inout_to_pins_en_i,
+  output logic [InoutNumber-1:0] inout_from_pins_o,
+
+  inout  logic [InoutNumber-1:0] inout_pins_io
+);
+  prim_pad_wrapper_pkg::pad_attr_t pad_attr = '{
+    default:'0,
+    drive_strength: '1
+  };
+
+  prim_pad_wrapper u_inout_pad[InoutNumber] (
+    .inout_io (inout_pins_io     ),
+    .in_o     (inout_from_pins_o ),
+    .ie_i     (1'b1              ),
+    .out_i    (inout_to_pins_i   ),
+    .oe_i     (inout_to_pins_en_i),
+    .attr_i   (pad_attr          ),
+
+    // Don't care
+    .in_raw_o   (),
+    // Unused in generic and Xilinx variant of the wrapper
+    .clk_scan_i (),
+    .scanmode_i (),
+    .pok_i      ()
+  );
+endmodule : padring

--- a/hw/vendor/lowrisc_sonata/rtl/fpga/rst_ctrl.sv
+++ b/hw/vendor/lowrisc_sonata/rtl/fpga/rst_ctrl.sv
@@ -1,0 +1,102 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Produces an active-low power-on-reset (PoR) on output `rst_no`. A reset will only happen once
+// `pll_locked_i` is set to indicate the systems PLL(s) have locked and clock(s) are stable. Further
+// resets can be triggered by the 'rst_btn_i' input (active high). This input is debounced so it can
+// be easily connected to a physical button.
+//
+// The PoR has three phases:
+// * phase 0 - Reset is left deasserted
+// * phase 1 - Reset is asserted and held asserted (giving a negative edge on rst_no from phase 0 to
+//   phase 1)
+// * phase 2 - Reset is deasserted (giving a positive edge on rst_no from phase 1 to phase 2)
+//
+// The 'ResetPhase0Count' and 'ResetPhase1Count' specify the length of time for phase 0 and phase
+// 1 in clock cycles (phase 2 is an unbounded length)
+//
+// When 'rst_btn_i' is asserted (set to 1) the controller is held at the beginning of phase 1 (reset
+// is asserted, and a negative edge seen on `rst_no` when the debounced `rst_btn_i` is first
+// asserted). It proceeds to phase 2 as normal when the debounced `rst_btn_i` is deasserted.
+//
+// Debouncing of `rst_btn_i` occurs internally to the module. The `rst_btn_i` input must be in
+// a single state for more than `DebounceCount` cycles for that state to take effect.
+//
+// If the `pll_locked_i` input goes low a new reset will be produced when it goes high again.
+//
+// The provided `clk_i` is assumed to always be stable and must be independent of the output reset
+// `rst_no` and of the PLL providing the `pll_locked_i` input.
+//
+// The `rst_no` signal is produced directly from a flop to prevent glitches. This flop is clocked
+// from `clk_i`.
+//
+// This module is designed for FPGA implementation as it relies on an 'initial' statement to set the
+// power-on contents of registers.
+
+module rst_ctrl #(
+  parameter int unsigned ResetPhase0Count = 5,
+  parameter int unsigned ResetPhase1Count = 200,
+  parameter int unsigned DebounceCount    = 500
+) (
+  input clk_i,
+  input pll_locked_i,
+  input rst_btn_i,
+
+  output rst_no
+);
+  localparam CounterWidth = $clog2(ResetPhase1Count + 1);
+
+  logic [CounterWidth-1:0] reset_counter_d, reset_counter_q;
+  logic rst_btn_debounce;
+  logic rst_n_d, debounce_rst_n_d, rst_n_q, debounce_rst_n_q;
+
+  initial begin
+    reset_counter_q = '0;
+    rst_n_q = 1'b1;
+    debounce_rst_n_q = 1'b1;
+  end
+
+  always_comb begin
+    reset_counter_d = reset_counter_q;
+
+    // The output is driven when the counter is between the value of phase
+    // 0 and phase 1. When a press on the reset button is detected, we can
+    // reset the counter value and make sure that the reset pulse is the same
+    // length as when we reset the system at startup.
+    if (rst_btn_debounce && (reset_counter_q >= ResetPhase0Count)) begin
+      reset_counter_d = ResetPhase0Count;
+    end else begin
+      if (pll_locked_i) begin
+        if (reset_counter_q < ResetPhase1Count) begin
+          reset_counter_d = reset_counter_q + 1;
+        end
+      end else begin
+        reset_counter_d = '0;
+      end
+    end
+  end
+
+  always_ff @(posedge clk_i) begin
+    reset_counter_q  <= reset_counter_d;
+    rst_n_q          <= rst_n_d;
+    debounce_rst_n_q <= debounce_rst_n_d;
+  end
+
+  debounce #(.ClkCount(DebounceCount)) u_rst_btn_debounce (
+    .clk_i,
+    .rst_ni(debounce_rst_n_q),
+
+    .btn_i(rst_btn_i),
+    .btn_o(rst_btn_debounce)
+  );
+
+  assign rst_n_d = reset_counter_q < ResetPhase0Count ? 1'b1 :
+                   reset_counter_q < ResetPhase1Count ? 1'b0 :
+                                                        1'b1;
+
+  assign debounce_rst_n_d = reset_counter_q <= ResetPhase0Count ? 1'b1 :
+                            reset_counter_q <  ResetPhase1Count ? 1'b0 :
+                                                                  1'b1;
+  assign rst_no = rst_n_q;
+endmodule

--- a/hw/vendor/sonata_fpga.core
+++ b/hw/vendor/sonata_fpga.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors (Sunburst project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:sunburst:sonata_fpga"
+description: "Bits of Sonata useful for FPGA targets"
+filesets:
+  files_sv:
+    depend:
+      - lowrisc:ibex:fpga_xilinx_shared
+    files:
+      - lowrisc_sonata/rtl/fpga/debounce.sv
+      - lowrisc_sonata/rtl/fpga/padring.sv
+      - lowrisc_sonata/rtl/fpga/rst_ctrl.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_sv

--- a/scratch_sw/bare_metal/checks/chip_check.cc
+++ b/scratch_sw/bare_metal/checks/chip_check.cc
@@ -93,5 +93,5 @@ extern "C" void entry_point(void *rwRoot) {
   // Signal test end to UVM testbench
   gpio->set_out_direct(0xDEADBEEF);
 
-  while (true);
+  while (true) asm volatile("wfi");
 }


### PR DESCRIPTION
New top-level and associated files for basic Sonata XL FPGA dev board support. Primary additions include pin-mapping XDC, Sonata XL-specific clock and reset generation, imported files from sonata-system, and various fusesoc .core files. Software loading currently limited to SRAM init built into the FPGA bitstream.