### PR TITLE
USB device: disable alert test

### DIFF
--- a/hw/vendor/lowrisc_ip/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/vendor/lowrisc_ip/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -29,7 +29,7 @@
                 // Common CIP test lists
                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
-                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
+                //"{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",

--- a/hw/vendor/patches/lowrisc_ip/usbdev/0004-Fix-DV.patch
+++ b/hw/vendor/patches/lowrisc_ip/usbdev/0004-Fix-DV.patch
@@ -67,7 +67,7 @@ index 36e748e..c985208 100644
 -                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 +                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/csr_tests.hjson",
 +                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/mem_tests.hjson",
-+                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
++                //"{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/alert_test.hjson",
 +                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/intr_test.hjson",
 +                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/tl_access_tests.hjson",
 +                "{proj_root}/hw/vendor/lowrisc_ip/dv/tools/dvsim/tests/sec_cm_tests.hjson",


### PR DESCRIPTION
These don't work under Sunburst chip. This commit contains both the Vendor patch and applying the patch.

Closes: https://github.com/lowRISC/sunburst-chip/issues/54