### PR TITLE
Fix PWM path in generate_regs.sh

### DIFF
--- a/util/generate_regs.sh
+++ b/util/generate_regs.sh
@@ -9,7 +9,7 @@ $GEN_REGS sw/device/regs/i2c_regs.h hw/vendor/lowrisc_ip/ip/i2c/data/i2c.hjson
 echo Generating register definitions for pattgen IP block
 $GEN_REGS sw/device/regs/pattgen_regs.h hw/vendor/lowrisc_ip/ip/pattgen/data/pattgen.hjson
 echo Generating register definitions for pwm IP block
-$GEN_REGS sw/device/regs/pwm_regs.h hw/vendor/lowrisc_ip/ip/pwm/data/pwm.hjson
+$GEN_REGS sw/device/regs/pwm_regs.h hw/vendor/lowrisc_ip_main/ip/pwm/data/pwm.hjson
 echo Generating register definitions for rv_plic IP block
 $GEN_REGS sw/device/regs/rv_plic_regs.h hw/top_chip/ip_autogen/rv_plic/data/rv_plic.hjson
 echo Generating register definitions for rv_timer IP block


### PR DESCRIPTION
Path needs updating following change to more recent PWM, in a different vendor sub-directory.